### PR TITLE
fix: Restrict CORS to specific origins for security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Environment
+ENVIRONMENT=development
+
+# CORS Origins (comma-separated for production)
+# Example: CORS_ORIGINS=https://app.example.com,https://admin.example.com
+CORS_ORIGINS=

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,6 @@ sqlalchemy
 psycopg2-binary
 redis
 pydantic
+pydantic-settings
 python-dotenv
 alembic

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,0 +1,31 @@
+import os
+from typing import List
+from pydantic_settings import BaseSettings
+from functools import lru_cache
+
+
+class Settings(BaseSettings):
+    environment: str = "development"
+    cors_origins: str = "http://localhost:3000,http://localhost:5173"
+    
+    @property
+    def allowed_origins(self) -> List[str]:
+        if self.environment == "production":
+            origins = os.getenv("CORS_ORIGINS", "")
+            return [origin.strip() for origin in origins.split(",") if origin.strip()]
+        else:
+            return [
+                "http://localhost:3000",
+                "http://localhost:5173",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:5173",
+            ]
+    
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,14 +1,16 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from .config import get_settings
+
+settings = get_settings()
 
 app = FastAPI(title="StellarInsure API", version="0.1.0")
 
-# CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allow_headers=["*"],
 )
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,115 @@
+"""CORS security tests for StellarInsure API"""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+
+class TestCORSConfiguration:
+    """Test suite for CORS security configuration"""
+
+    def test_development_allows_localhost_origins(self):
+        """Test that development environment allows localhost origins"""
+        from src.main import app
+        
+        client = TestClient(app)
+        
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+        
+        assert response.status_code == 200
+        assert "access-control-allow-origin" in response.headers
+
+    def test_development_allows_localhost_5173(self):
+        """Test that development allows Vite default port"""
+        from src.main import app
+        
+        client = TestClient(app)
+        
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+        
+        assert response.status_code == 200
+        assert "access-control-allow-origin" in response.headers
+
+    @patch.dict("os.environ", {"ENVIRONMENT": "production", "CORS_ORIGINS": "https://app.example.com,https://admin.example.com"})
+    def test_production_allows_only_whitelisted_origins(self):
+        """Test that production only allows whitelisted origins"""
+        from src.config import get_settings
+        
+        get_settings.cache_clear()
+        settings = get_settings()
+        
+        assert settings.environment == "production"
+        assert settings.allowed_origins == ["https://app.example.com", "https://admin.example.com"]
+
+    @patch.dict("os.environ", {"ENVIRONMENT": "production", "CORS_ORIGINS": ""})
+    def test_production_empty_origins(self):
+        """Test that production with empty CORS_ORIGINS returns empty list"""
+        from src.config import get_settings
+        
+        get_settings.cache_clear()
+        settings = get_settings()
+        
+        assert settings.environment == "production"
+        assert settings.allowed_origins == []
+
+    def test_config_cache(self):
+        """Test that settings are properly cached"""
+        from src.config import get_settings
+        
+        settings1 = get_settings()
+        settings2 = get_settings()
+        
+        assert settings1 is settings2
+
+    def test_credentials_enabled(self):
+        """Test that credentials are enabled for CORS"""
+        from src.main import app
+        
+        client = TestClient(app)
+        
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+        
+        assert "access-control-allow-credentials" in response.headers
+
+    def test_allowed_methods(self):
+        """Test that specific HTTP methods are allowed"""
+        from src.main import app
+        
+        client = TestClient(app)
+        
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+            }
+        )
+        
+        assert response.status_code == 200
+
+    @patch.dict("os.environ", {"ENVIRONMENT": "development"})
+    def test_wildcard_not_allowed_in_any_environment(self):
+        """Test that wildcard origin is never allowed"""
+        from src.config import get_settings
+        
+        get_settings.cache_clear()
+        settings = get_settings()
+        
+        assert "*" not in settings.allowed_origins


### PR DESCRIPTION
## Summary
- Restricts CORS configuration from allowing all origins (`*`) to specific whitelisted domains
- Implements environment-based origin configuration for secure production deployment
- Adds comprehensive CORS security tests to ensure proper configuration

## Changes
- Created `backend/src/config.py` with environment-aware settings using pydantic-settings
- Updated `backend/src/main.py` to use restricted CORS origins instead of wildcard
- Added `backend/.env.example` with CORS configuration examples
- Updated `backend/requirements.txt` to include pydantic-settings dependency
- Created `backend/tests/test_cors.py` with comprehensive CORS security tests

## Security Improvements
- **Development**: Allows localhost origins (ports 3000, 5173) for local development
- **Production**: Only allows origins specified in `CORS_ORIGINS` environment variable
- **No wildcard**: Removes `*` from allowed origins in all environments
- **Specific methods**: Limits HTTP methods to GET, POST, PUT, DELETE, PATCH, OPTIONS

## Testing
- Tests for development localhost origins
- Tests for production whitelisted origins
- Tests for empty CORS origins in production
- Tests for credential and method handling
- Tests to ensure wildcard is never allowed

## Acceptance Criteria Met
- ✅ Only whitelisted origins are allowed
- ✅ Production has strict CORS policy
- ✅ Development allows localhost
- ✅ No security warnings in production (no wildcard usage)

Closes #1