### PR TITLE
feat(frontend): implement loading skeleton library

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1146,6 +1146,37 @@ dt,
   }
 }
 
+/* =========================================
+   Skeleton Loading States
+   ========================================= */
+@keyframes ob-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.ob-skeleton {
+  background-color: var(--surface-2, rgba(0, 0, 0, 0.04));
+  border-radius: var(--radius-sm, 4px);
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0,
+    rgba(255, 255, 255, 0.6) 20%,
+    rgba(255, 255, 255, 0) 40%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  background-size: 200% 100%;
+  animation: ob-skeleton-shimmer 1.5s infinite linear;
+}
+
+.ob-skeleton-text-group {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
@@ -1156,9 +1187,14 @@ dt,
   .tx-detail-panel,
   .ob-content,
   .ob-dot,
-  .skip-link {
+  .skip-link,
+  .ob-skeleton {
     animation: none;
     transition: none;
+  }
+
+  .ob-skeleton {
+    background-image: none;
   }
 }
 

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { startTransition, useDeferredValue, useMemo, useState } from "react";
+import React, { startTransition, useEffect, useDeferredValue, useMemo, useState } from "react";
 import Link from "next/link";
 
 import { Icon } from "@/components/icon";
+import { Skeleton } from "@/components/skeleton";
 
 type TxType = "premium" | "payout" | "refund" | "all";
 type TxStatus = "successful" | "pending" | "failed" | "all";
@@ -96,10 +97,16 @@ export default function TransactionHistoryPage() {
   const [statusFilter, setStatusFilter] = useState<TxStatus>("all");
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const deferredTypeFilter = useDeferredValue(typeFilter);
   const deferredStatusFilter = useDeferredValue(statusFilter);
   const isFiltering =
     deferredTypeFilter !== typeFilter || deferredStatusFilter !== statusFilter;
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 1200);
+    return () => clearTimeout(timer);
+  }, []);
 
   const filtered = useMemo(() => {
     return MOCK_TRANSACTIONS.filter((tx) => {
@@ -198,7 +205,40 @@ export default function TransactionHistoryPage() {
         </p>
       </div>
 
-      {paginated.length === 0 ? (
+      {isLoading ? (
+        <div
+          className="tx-table-wrapper motion-panel"
+          role="region"
+          aria-label="Loading transactions"
+          aria-busy="true"
+        >
+          <span className="visually-hidden">Loading transactions, please wait.</span>
+          <table className="tx-table">
+            <thead>
+              <tr>
+                <th scope="col">Date</th>
+                <th scope="col">Type</th>
+                <th scope="col">Amount (XLM)</th>
+                <th scope="col">Status</th>
+                <th scope="col">Hash</th>
+                <th scope="col">Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <tr key={`sk-row-${i}`} className="tx-row">
+                  <td><Skeleton style={{ height: "14px", width: "120px" }} /></td>
+                  <td><Skeleton style={{ height: "22px", width: "64px", borderRadius: "20px" }} /></td>
+                  <td><Skeleton style={{ height: "14px", width: "60px" }} /></td>
+                  <td><Skeleton style={{ height: "22px", width: "80px", borderRadius: "20px" }} /></td>
+                  <td><Skeleton style={{ height: "14px", width: "100px" }} /></td>
+                  <td><Skeleton style={{ height: "24px", width: "28px", borderRadius: "4px" }} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : paginated.length === 0 ? (
         <div className="tx-empty" role="status">
           <span className="tx-empty-icon" aria-hidden="true">
             <Icon name="document" size="lg" tone="muted" />
@@ -212,6 +252,32 @@ export default function TransactionHistoryPage() {
           aria-label="Transaction list"
           aria-busy={isFiltering}
         >
+          {isFiltering ? (
+            <table className="tx-table">
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Type</th>
+                  <th scope="col">Amount (XLM)</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Hash</th>
+                  <th scope="col">Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <tr key={`filter-sk-${i}`} className="tx-row">
+                    <td><Skeleton style={{ height: "14px", width: "120px" }} /></td>
+                    <td><Skeleton style={{ height: "22px", width: "64px", borderRadius: "20px" }} /></td>
+                    <td><Skeleton style={{ height: "14px", width: "60px" }} /></td>
+                    <td><Skeleton style={{ height: "22px", width: "80px", borderRadius: "20px" }} /></td>
+                    <td><Skeleton style={{ height: "14px", width: "100px" }} /></td>
+                    <td><Skeleton style={{ height: "24px", width: "28px", borderRadius: "4px" }} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
           <table className="tx-table" aria-labelledby="tx-history-title">
             <thead>
               <tr>
@@ -331,6 +397,7 @@ export default function TransactionHistoryPage() {
               ))}
             </tbody>
           </table>
+          )}
         </div>
       )}
 

--- a/frontend/src/app/policies/[policyId]/page.tsx
+++ b/frontend/src/app/policies/[policyId]/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 
 import { Icon } from "@/components/icon";
+import { Skeleton, SkeletonText } from "@/components/skeleton";
 
 type PolicyStatus = "Active" | "Claim Pending" | "Claim Approved";
 type ClaimStatus = "Approved" | "Pending";
@@ -243,16 +244,59 @@ export default function PolicyDetailPage({
 
   if (isLoading) {
     return (
-      <main id="main-content" className="policy-page">
-        <section className="policy-shell policy-shell--loading" aria-busy="true">
-          <span className="eyebrow">Policy Detail</span>
-          <span className="state-icon" aria-hidden="true">
-            <Icon name="clock" size="lg" tone="muted" />
-          </span>
-          <h1>Loading policy snapshot</h1>
-          <p className="state-copy">
-            Pulling the latest policy summary, claim activity, and print metadata.
-          </p>
+      <main id="main-content" className="policy-page" aria-busy="true">
+        <span className="visually-hidden">Loading policy data, please wait.</span>
+        <section className="policy-shell">
+          {/* Header */}
+          <div className="policy-header" style={{ marginBottom: "2rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1rem", flexWrap: "wrap" }}>
+              <div style={{ flex: 1 }}>
+                <Skeleton style={{ width: "80px", height: "12px", marginBottom: "0.75rem" }} />
+                <Skeleton style={{ width: "55%", height: "32px", marginBottom: "0.5rem" }} />
+                <Skeleton style={{ width: "30%", height: "14px" }} />
+              </div>
+              <div style={{ display: "flex", gap: "0.75rem" }}>
+                <Skeleton style={{ width: "110px", height: "38px", borderRadius: "8px" }} />
+                <Skeleton style={{ width: "110px", height: "38px", borderRadius: "8px" }} />
+              </div>
+            </div>
+          </div>
+
+          {/* Key Metrics Grid */}
+          <div className="policy-grid" style={{ marginBottom: "2rem" }}>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={`metric-sk-${i}`} className="hero-card" style={{ padding: "1.25rem" }}>
+                <Skeleton style={{ width: "28px", height: "28px", borderRadius: "50%", marginBottom: "0.75rem" }} />
+                <Skeleton style={{ width: "60%", height: "11px", marginBottom: "0.5rem" }} />
+                <Skeleton style={{ width: "80%", height: "20px" }} />
+              </div>
+            ))}
+          </div>
+
+          {/* Two-column panel area */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem", marginBottom: "2rem" }}>
+            {Array.from({ length: 2 }).map((_, j) => (
+              <div key={`panel-sk-${j}`} className="panel" style={{ padding: "1.5rem" }}>
+                <Skeleton style={{ width: "40%", height: "14px", marginBottom: "1rem" }} />
+                <SkeletonText lines={4} />
+              </div>
+            ))}
+          </div>
+
+          {/* Timeline / claim list rows */}
+          <div className="panel" style={{ padding: "1.5rem" }}>
+            <Skeleton style={{ width: "35%", height: "14px", marginBottom: "1.25rem" }} />
+            {Array.from({ length: 3 }).map((_, k) => (
+              <div key={`row-sk-${k}`} style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
+                <Skeleton style={{ width: "36px", height: "36px", borderRadius: "50%", flexShrink: 0 }} />
+                <div style={{ flex: 1 }}>
+                  <Skeleton style={{ width: "50%", height: "12px", marginBottom: "0.4rem" }} />
+                  <Skeleton style={{ width: "30%", height: "10px" }} />
+                </div>
+                <Skeleton style={{ width: "70px", height: "24px", borderRadius: "20px" }} />
+              </div>
+            ))}
+          </div>
         </section>
       </main>
     );

--- a/frontend/src/components/skeleton.tsx
+++ b/frontend/src/components/skeleton.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Basic shimmering skeleton block.
+ * Usage: <Skeleton className="w-full h-8" /> or with inline style width/height.
+ */
+export function Skeleton({
+  className = "",
+  style,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`ob-skeleton ${className}`}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Multi-line skeleton text.
+ * Renders multiple lines with decreasing widths for a natural text shape.
+ */
+export function SkeletonText({
+  lines = 3,
+  className = "",
+  style,
+}: { lines?: number } & React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`ob-skeleton-text-group ${className}`} style={style} aria-hidden="true">
+      {Array.from({ length: lines }).map((_, i) => {
+        // Simple logic: last line is shorter if there's more than 1
+        const width = lines > 1 && i === lines - 1 ? "60%" : "100%";
+        return (
+          <div
+            key={`skeleton-line-${i}`}
+            className="ob-skeleton"
+            style={{ width, height: "1em", marginBottom: "0.5em" }}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add reusable Skeleton and SkeletonText components (skeleton.tsx)
- Add @keyframes ob-skeleton-shimmer and .ob-skeleton CSS classes to globals.css
- Respect prefers-reduced-motion by disabling animation for accessibility
- Replace policy detail loading state with a structured PolicySkeleton layout
- Add TransactionTableSkeleton to history page for initial load and filter transitions

Closes #85