### PR TITLE
feat: add formatted coverage amount inputs for #73

### DIFF
--- a/frontend/src/app/create/page.test.tsx
+++ b/frontend/src/app/create/page.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CreatePolicyPage from "./page";
+
+describe("CreatePolicyPage", () => {
+  it("formats the coverage amount input as the user types", () => {
+    render(<CreatePolicyPage />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
+
+    const coverageInput = screen.getByLabelText(/coverage amount \(xlm\)/i);
+    fireEvent.change(coverageInput, { target: { value: "12000.5" } });
+
+    expect(coverageInput).toHaveValue("12,000.5");
+  });
+
+  it("shows a max constraint error when coverage exceeds the supported limit", () => {
+    render(<CreatePolicyPage />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
+
+    const coverageInput = screen.getByLabelText(/coverage amount \(xlm\)/i);
+    fireEvent.change(coverageInput, { target: { value: "1000001" } });
+    fireEvent.blur(coverageInput);
+
+    expect(screen.getByText(/coverage amount cannot exceed 1,000,000.00 xlm/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue to review/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Link from "next/link";
 
+import { AmountInput, formatAssetAmount, parseAmountInput } from "@/components/amount-input";
 import { Icon } from "@/components/icon";
 import { PolicyTypeSelector, type PolicyType } from "@/components/policy-type-selector";
 import { TransactionTimeline, DEFAULT_TX_STEPS, type TimelineStep } from "@/components/transaction-timeline";
@@ -32,6 +33,8 @@ const STEP_LABELS = [
   "Review",
   "Submit",
 ];
+
+const MAX_COVERAGE_AMOUNT = 1_000_000;
 
 function StepIndicator({ current }: { current: CreateStep }) {
   return (
@@ -73,6 +76,7 @@ export default function CreatePolicyPage() {
     return 0;
   });
   const [txSteps, setTxSteps] = useState<TimelineStep[]>(DEFAULT_TX_STEPS);
+  const [coverageTouched, setCoverageTouched] = useState(false);
 
   function updateDraft<K extends keyof PolicyDraft>(field: K, value: PolicyDraft[K]) {
     setDraft({ ...draft, [field]: value });
@@ -84,6 +88,12 @@ export default function CreatePolicyPage() {
   }
 
   function handleConfigureNext() {
+    setCoverageTouched(true);
+
+    if (!isConfigValid) {
+      return;
+    }
+
     setStep(2);
   }
 
@@ -125,8 +135,18 @@ export default function CreatePolicyPage() {
     }, 3600);
   }
 
+  const parsedCoverageAmount = parseAmountInput(draft.coverageAmount);
+  const coverageError =
+    draft.coverageAmount.trim() === ""
+      ? "Enter a coverage amount to continue."
+      : parsedCoverageAmount === null || parsedCoverageAmount <= 0
+        ? "Enter a valid coverage amount in XLM."
+        : parsedCoverageAmount > MAX_COVERAGE_AMOUNT
+          ? `Coverage amount cannot exceed ${formatAssetAmount(MAX_COVERAGE_AMOUNT)} XLM.`
+          : undefined;
+
   const isConfigValid =
-    draft.coverageAmount.trim() !== "" &&
+    coverageError === undefined &&
     draft.triggerCondition.trim() !== "" &&
     draft.premium.trim() !== "" &&
     draft.duration.trim() !== "";
@@ -164,17 +184,23 @@ export default function CreatePolicyPage() {
           <div className="form-grid">
             <label className="field">
               <span className="field__label">Coverage Amount (XLM)</span>
-              <input
+              <AmountInput
                 className="field__input"
-                type="number"
-                inputMode="decimal"
-                min="0"
-                step="0.01"
-                placeholder="e.g. 5000"
+                aria-invalid={Boolean(coverageError) && coverageTouched}
+                aria-describedby={coverageError && coverageTouched ? "coverage-error" : "coverage-hint"}
+                placeholder="e.g. 5,000.00"
                 value={draft.coverageAmount}
-                onChange={(e) => updateDraft("coverageAmount", e.target.value)}
+                onChange={(value) => updateDraft("coverageAmount", value)}
+                onBlur={() => setCoverageTouched(true)}
               />
-              <span className="field__hint">Maximum payout if the trigger condition is met.</span>
+              <span id="coverage-hint" className="field__hint">
+                Maximum payout if the trigger condition is met. Limit: {formatAssetAmount(MAX_COVERAGE_AMOUNT)} XLM.
+              </span>
+              {coverageError && coverageTouched ? (
+                <span id="coverage-error" className="field__error">
+                  {coverageError}
+                </span>
+              ) : null}
             </label>
 
             <label className="field">
@@ -252,7 +278,7 @@ export default function CreatePolicyPage() {
               </div>
               <div>
                 <dt>Coverage</dt>
-                <dd>{draft.coverageAmount} XLM</dd>
+                <dd>{parsedCoverageAmount !== null ? formatAssetAmount(parsedCoverageAmount) : draft.coverageAmount} XLM</dd>
               </div>
               <div>
                 <dt>Premium</dt>

--- a/frontend/src/app/policies/[policyId]/page.test.tsx
+++ b/frontend/src/app/policies/[policyId]/page.test.tsx
@@ -50,4 +50,41 @@ describe("PolicyDetailPage", () => {
     expect(screen.getByText(/enter a valid email address/i)).toBeInTheDocument();
     expect(screen.getByText(/enter a phone number/i)).toBeInTheDocument();
   });
+
+  it("formats the review amount and rejects values above coverage", () => {
+    render(<PolicyDetailPage params={{ policyId: "weather-alpha" }} />);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const amountInput = screen.getByLabelText(/review amount/i);
+    fireEvent.change(amountInput, { target: { value: "12500" } });
+
+    expect(amountInput).toHaveValue("12,500");
+
+    fireEvent.click(screen.getByRole("button", { name: /save handoff draft/i }));
+
+    expect(screen.getByText(/requested review amount cannot exceed the policy coverage/i)).toBeInTheDocument();
+  });
+
+  it("renders the error state when policy data cannot be loaded", () => {
+    render(<PolicyDetailPage params={{ policyId: "sync-check" }} />);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByRole("heading", { name: /policy data is temporarily unavailable/i })).toBeInTheDocument();
+  });
+
+  it("renders the empty state when the requested policy does not exist", () => {
+    render(<PolicyDetailPage params={{ policyId: "missing-policy" }} />);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByRole("heading", { name: /policy not found/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/policies/[policyId]/page.tsx
+++ b/frontend/src/app/policies/[policyId]/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 
+import { AmountInput, formatAssetAmount, parseAmountInput } from "@/components/amount-input";
 import { Icon } from "@/components/icon";
 import { Skeleton, SkeletonText } from "@/components/skeleton";
 import { TransactionModal } from "@/components/transaction-modal";
@@ -97,13 +98,6 @@ const POLICY_RECORDS: Record<string, PolicyRecord | "error"> = {
   "sync-check": "error",
 };
 
-function formatCurrency(amount: number) {
-  return amount.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-}
-
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-US", {
     year: "numeric",
@@ -195,7 +189,7 @@ export default function PolicyDetailPage({
 
   function validateForm(policy: PolicyRecord): FormErrors {
     const errors: FormErrors = {};
-    const amount = Number(formState.amount);
+    const amount = parseAmountInput(formState.amount);
 
     if (formState.fullName.trim().length < 2) {
       errors.fullName = "Enter the contact name you want support to reference.";
@@ -209,7 +203,7 @@ export default function PolicyDetailPage({
       errors.phone = "Enter a phone number that support can use on mobile.";
     }
 
-    if (!Number.isFinite(amount) || amount <= 0) {
+    if (amount === null || amount <= 0) {
       errors.amount = "Enter a valid payout review amount.";
     } else if (amount > policy.coverageAmount) {
       errors.amount = "Requested review amount cannot exceed the policy coverage.";
@@ -397,11 +391,11 @@ export default function PolicyDetailPage({
             <dl className="definition-grid">
               <div>
                 <dt>Coverage</dt>
-                <dd>{formatCurrency(currentPolicy.coverageAmount)} XLM</dd>
+                <dd>{formatAssetAmount(currentPolicy.coverageAmount)} XLM</dd>
               </div>
               <div>
                 <dt>Premium</dt>
-                <dd>{formatCurrency(currentPolicy.premium)} XLM</dd>
+                <dd>{formatAssetAmount(currentPolicy.premium)} XLM</dd>
               </div>
               <div>
                 <dt>Type</dt>
@@ -483,7 +477,7 @@ export default function PolicyDetailPage({
                     </div>
                     <div>
                       <dt>Requested amount</dt>
-                      <dd>{formatCurrency(claim.amount)} XLM</dd>
+                      <dd>{formatAssetAmount(claim.amount)} XLM</dd>
                     </div>
                     <div>
                       <dt>Evidence bundle</dt>
@@ -572,21 +566,17 @@ export default function PolicyDetailPage({
 
               <label className="field">
                 <span className="field__label">Review amount</span>
-                <input
+                <AmountInput
                   ref={amountRef}
                   className="field__input"
                   name="amount"
-                  inputMode="decimal"
-                  min="0"
-                  step="0.01"
-                  type="number"
                   value={formState.amount}
-                  onChange={(event) => setField("amount", event.target.value)}
+                  onChange={(value) => setField("amount", value)}
                   aria-invalid={Boolean(formErrors.amount)}
                   aria-describedby={formErrors.amount ? "amount-error" : "amount-hint"}
                 />
                 <span id="amount-hint" className="field__hint">
-                  Maximum review amount: {formatCurrency(currentPolicy.coverageAmount)} XLM
+                  Maximum review amount: {formatAssetAmount(currentPolicy.coverageAmount)} XLM
                 </span>
                 {formErrors.amount ? (
                   <span id="amount-error" className="field__error">

--- a/frontend/src/components/amount-input.tsx
+++ b/frontend/src/components/amount-input.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+
+function formatIntegerPart(value: string) {
+  if (!value) {
+    return "";
+  }
+
+  const normalized = value.replace(/^0+(?=\d)/, "");
+  const digits = normalized || "0";
+  return digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export function normalizeAmountInput(value: string, maxDecimals = 2) {
+  const sanitized = value.replace(/[^\d.]/g, "");
+
+  if (!sanitized) {
+    return "";
+  }
+
+  const firstDecimalIndex = sanitized.indexOf(".");
+  const hasDecimal = firstDecimalIndex >= 0;
+  const integerRaw = hasDecimal ? sanitized.slice(0, firstDecimalIndex) : sanitized;
+  const decimalRaw = hasDecimal
+    ? sanitized.slice(firstDecimalIndex + 1).replace(/\./g, "").slice(0, maxDecimals)
+    : "";
+
+  const formattedInteger = formatIntegerPart(integerRaw);
+
+  if (hasDecimal) {
+    const integerValue = formattedInteger || "0";
+    return `${integerValue}.${decimalRaw}`;
+  }
+
+  return formattedInteger;
+}
+
+export function parseAmountInput(value: string) {
+  if (!value.trim()) {
+    return null;
+  }
+
+  const normalized = value.replace(/,/g, "");
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function formatAssetAmount(value: number) {
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+type AmountInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type" | "value" | "onChange"
+> & {
+  value: string;
+  onChange: (value: string) => void;
+  maxDecimals?: number;
+  formatOnBlur?: boolean;
+};
+
+export const AmountInput = React.forwardRef<HTMLInputElement, AmountInputProps>(function AmountInput(
+  {
+    maxDecimals = 2,
+    formatOnBlur = false,
+    inputMode = "decimal",
+    onBlur,
+    onChange,
+    value,
+    ...props
+  },
+  ref,
+) {
+  return (
+    <input
+      {...props}
+      ref={ref}
+      type="text"
+      inputMode={inputMode}
+      value={value}
+      onChange={(event) => onChange(normalizeAmountInput(event.target.value, maxDecimals))}
+      onBlur={(event) => {
+        if (formatOnBlur) {
+          const parsed = parseAmountInput(value);
+          if (parsed !== null) {
+            onChange(formatAssetAmount(parsed));
+          }
+        }
+
+        onBlur?.(event);
+      }}
+    />
+  );
+});


### PR DESCRIPTION
Closes #73

Changes
add a shared formatted amount input for XLM/currency-style entry
enforce coverage amount validation with positive-value and max-limit checks on the create policy flow
show formatted coverage values in the review step for clearer confirmation before submit
reuse formatted amount entry on the policy detail assistance form for consistent mobile and desktop behavior
add frontend tests covering amount formatting, max validation, and policy loading/error/empty states