### PR TITLE
Resolve issues #226, #219, #66, and #31

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a reproducible defect in StellarInsure.
+title: "[Bug] "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide enough detail for us to reproduce quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect to happen?
+      placeholder: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Include exact steps to reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser/OS, network, branch, and any wallet details.
+      placeholder: macOS 14, Chrome 124, testnet wallet connected, branch feature/...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs, stack traces, screenshots, or recordings.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:security@stellarinsure.io
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a product or technical enhancement.
+title: "[Feature] "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user problem are you trying to solve?
+      placeholder: As a policyholder, I want ... so that ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want to see.
+      placeholder: Add/update ... with ...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define clear, testable criteria for completion.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches or tradeoffs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- What changed and why?
+
+## Linked issues
+- Closes #
+
+## Test plan
+- [ ] Frontend tests pass (`npm test` in `frontend`)
+- [ ] Backend tests pass (`pytest` in `backend`)
+- [ ] Smart contract tests pass (`cargo test` in `smartcontract`)
+- [ ] Manually validated affected flows
+
+## Checklist
+- [ ] Code follows project style conventions
+- [ ] New/updated tests cover the change
+- [ ] Docs updated when behavior changed
+- [ ] No secrets or credentials added

--- a/frontend/src/app/create/create-page-client.test.tsx
+++ b/frontend/src/app/create/create-page-client.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CreatePolicyPageClient from "./create-page-client";
+
+vi.mock("@/components/wallet-provider", () => ({
+  useWallet: () => ({
+    isConnected: true,
+    message: "Wallet connected.",
+    status: "connected",
+  }),
+}));
+
+const signTransactionMock = vi.fn();
+vi.mock("@stellar/freighter-api", () => ({
+  signTransaction: (...args: unknown[]) => signTransactionMock(...args),
+}));
+
+vi.mock("@/components/trigger-condition-builder", () => ({
+  TriggerConditionBuilder: ({ onChange }: { onChange: (value: string) => void }) => (
+    <input
+      aria-label="Trigger mock input"
+      onChange={(event) => onChange(event.target.value)}
+      placeholder="Trigger mock input"
+      type="text"
+    />
+  ),
+}));
+
+vi.mock("@/components/oracle-source-selector", () => ({
+  OracleSourceSelector: ({
+    state,
+    selectedId,
+    onSelect,
+  }: {
+    state: string;
+    selectedId: string | null;
+    onSelect: (providerId: string) => void;
+  }) =>
+    state === "ready" ? (
+      <label>
+        <input
+          checked={selectedId === "weatherlink-prime"}
+          name="oracle-provider"
+          onChange={() => onSelect("weatherlink-prime")}
+          type="radio"
+        />
+        WeatherLink Prime
+      </label>
+    ) : (
+      <p>Loading oracle providers...</p>
+    ),
+}));
+
+describe("CreatePolicyPageClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    signTransactionMock.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("moves from policy type selection into configure step", () => {
+    render(<CreatePolicyPageClient />);
+    fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
+
+    expect(screen.getByRole("heading", { name: /configure your policy/i })).toBeInTheDocument();
+  });
+
+  it("applies form validation for invalid coverage values", () => {
+    render(<CreatePolicyPageClient />);
+    fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
+
+    const coverageInput = screen.getByLabelText(/coverage amount/i);
+    fireEvent.change(coverageInput, { target: { value: "1000001" } });
+    fireEvent.blur(coverageInput);
+
+    expect(screen.getByText(/coverage amount cannot exceed 1,000,000.00 xlm/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue to review/i })).toBeDisabled();
+  });
+
+  it("submits successfully with mocked wallet signature", async () => {
+    localStorage.setItem(
+      "stellarinsure-policy-draft",
+      JSON.stringify({
+        policyType: "weather",
+        coverageAmount: "5000",
+        premium: "120",
+        triggerCondition: "rainfall > 50",
+        duration: "90",
+        oracleProvider: "weatherlink-prime",
+      }),
+    );
+    render(<CreatePolicyPageClient />);
+
+    expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /sign and submit/i }));
+    });
+    expect(signTransactionMock).toHaveBeenCalled();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      vi.advanceTimersByTime(3500);
+    });
+
+    expect(screen.getByText(/policy created successfully/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -175,6 +175,91 @@ textarea {
   gap: 0.75rem;
 }
 
+.mobile-nav-toggle {
+  display: none;
+  min-height: 2.75rem;
+  padding: 0.7rem 1rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--card-border);
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.mobile-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(16, 37, 66, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+  z-index: 80;
+}
+
+.mobile-drawer-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mobile-drawer {
+  position: fixed;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: min(84vw, 22rem);
+  background: var(--surface);
+  border-left: 1px solid var(--card-border);
+  box-shadow: var(--shadow);
+  transform: translateX(100%);
+  transition: transform 200ms ease;
+  z-index: 90;
+  padding: 1.25rem;
+  display: grid;
+  align-content: start;
+  gap: 1.25rem;
+}
+
+.mobile-drawer.is-open {
+  transform: translateX(0);
+}
+
+.mobile-drawer__links {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.mobile-drawer__links a {
+  display: inline-flex;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  background: var(--surface-wash);
+}
+
+.mobile-drawer__links a[aria-current="page"] {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.mobile-drawer__actions {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.page-context {
+  margin-bottom: 1.25rem;
+  padding: 1rem 1.25rem;
+}
+
+.page-context h2 {
+  font-size: var(--step-2);
+  margin: 0 0 0.35rem;
+}
+
+.page-context p {
+  margin: 0;
+}
+
 .brand {
   display: inline-flex;
   align-items: center;
@@ -1619,6 +1704,17 @@ dt,
   .topbar-actions {
     width: 100%;
     display: grid;
+  }
+
+  .nav-links--desktop,
+  .topbar-actions--desktop {
+    display: none;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .wallet-connection {

--- a/frontend/src/app/history/history-page-client.test.tsx
+++ b/frontend/src/app/history/history-page-client.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import HistoryPageClient from "./history-page-client";
+
+describe("HistoryPageClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("filters transactions by type and status", async () => {
+    render(<HistoryPageClient />);
+
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+
+    fireEvent.change(screen.getByLabelText(/type/i), { target: { value: "refund" } });
+    fireEvent.change(screen.getByLabelText(/status/i), { target: { value: "successful" } });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    expect(screen.getByText(/6 transactions found/i)).toBeInTheDocument();
+  });
+
+  it("paginates transaction list", () => {
+    render(<HistoryPageClient />);
+
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+
+    const nextButton = screen.getByRole("button", { name: /next page/i });
+    expect(nextButton).toBeEnabled();
+
+    fireEvent.click(nextButton);
+
+    expect(screen.getByText(/showing 9-16 of 38/i)).toBeInTheDocument();
+  });
+
+  it("expands and collapses transaction details", () => {
+    render(<HistoryPageClient />);
+
+    act(() => {
+      vi.advanceTimersByTime(1300);
+    });
+
+    const rows = screen.getAllByRole("row");
+    const firstDataRow = rows[1];
+    const expandButton = within(firstDataRow).getByRole("button", { name: /expand transaction/i });
+    fireEvent.click(expandButton);
+
+    expect(screen.getByLabelText(/transaction detail/i)).toBeInTheDocument();
+
+    const collapseButton = within(firstDataRow).getByRole("button", { name: /collapse transaction/i });
+    fireEvent.click(collapseButton);
+
+    expect(screen.queryByLabelText(/transaction detail/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,11 +2,10 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { ErrorBoundary } from "@/components/error-boundary";
+import { SiteHeader } from "@/components/site-header";
 import { StructuredData } from "@/components/structured-data";
-import { WalletConnectionButton } from "@/components/wallet-connection-button";
 import { WalletProvider } from "@/components/wallet-provider";
 import { MaintenanceBanner } from "@/components/maintenance-banner";
-import { LanguageSwitcher } from "@/components/language-switcher";
 import { OnboardingFlow } from "@/components/onboarding";
 import { PageTransition } from "@/components/page-transition";
 import { LanguageProvider } from "@/i18n/provider";
@@ -84,41 +83,18 @@ export default function RootLayout({
             </a>
             <div className="page-shell">
               <MaintenanceBanner />
+              <SiteHeader />
 
-                <header className="topbar" aria-label="Primary">
-                  <Link className="brand" href="/">
-                    <span className="brand-mark" aria-hidden="true">
-                      SI
-                    </span>
-                    <span className="brand-copy">
-                      <strong>StellarInsure</strong>
-                      <span>Parametric cover on Stellar</span>
-                    </span>
-                  </Link>
+              <PageTransition>{children}</PageTransition>
 
-                  <nav className="nav-links" aria-label="Section navigation">
-                    <Link href="/">Overview</Link>
-                    <Link href="/create">Create Policy</Link>
-                    <Link href="/policies">My Policies</Link>
-                    <Link href="/history">History</Link>
-                  </nav>
-
-                  <div className="topbar-actions">
-                    <WalletConnectionButton />
-                    <LanguageSwitcher />
-                  </div>
-                </header>
-
-                <PageTransition>{children}</PageTransition>
-
-                <footer className="footer">
-                  <span>Built for transparent policy creation, automated claims, and multilingual access.</span>
-                  <nav aria-label="Legal">
-                    <Link href="/legal/terms">Terms of Service</Link>
-                    <Link href="/legal/privacy">Privacy Policy</Link>
-                  </nav>
-                </footer>
-              </div>
+              <footer className="footer">
+                <span>Built for transparent policy creation, automated claims, and multilingual access.</span>
+                <nav aria-label="Legal">
+                  <Link href="/legal/terms">Terms of Service</Link>
+                  <Link href="/legal/privacy">Privacy Policy</Link>
+                </nav>
+              </footer>
+            </div>
             </WalletProvider>
           </LanguageProvider>
         </ErrorBoundary>

--- a/frontend/src/components/site-header.tsx
+++ b/frontend/src/components/site-header.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { LanguageSwitcher } from "@/components/language-switcher";
+import { WalletConnectionButton } from "@/components/wallet-connection-button";
+
+type NavItem = {
+  href: string;
+  label: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/", label: "Overview" },
+  { href: "/create", label: "Create Policy" },
+  { href: "/policies", label: "My Policies" },
+  { href: "/history", label: "History" },
+];
+
+const PAGE_CONTEXT: Record<string, { title: string; description: string }> = {
+  "/": {
+    title: "Overview",
+    description: "Monitor coverage, payouts, and protocol activity from one place.",
+  },
+  "/create": {
+    title: "Create Policy",
+    description: "Build policy terms, review pricing, and submit coverage on Stellar.",
+  },
+  "/policies": {
+    title: "Policy Portfolio",
+    description: "Review active and historical policies with real-time status updates.",
+  },
+  "/history": {
+    title: "Transaction History",
+    description: "Inspect premium, payout, and refund events with explorer deep links.",
+  },
+};
+
+function getPageContext(pathname: string) {
+  if (pathname.startsWith("/policies/")) {
+    return {
+      title: "Policy Details",
+      description: "Inspect policy status, claim history, and payout readiness.",
+    };
+  }
+
+  if (pathname.startsWith("/legal/")) {
+    return {
+      title: "Legal",
+      description: "Review protocol terms, responsibilities, and privacy commitments.",
+    };
+  }
+
+  return PAGE_CONTEXT[pathname] ?? PAGE_CONTEXT["/"];
+}
+
+export function SiteHeader() {
+  const pathname = usePathname() ?? "/";
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const context = useMemo(() => getPageContext(pathname), [pathname]);
+
+  function closeDrawer() {
+    setDrawerOpen(false);
+  }
+
+  return (
+    <>
+      <header className="topbar" aria-label="Primary">
+        <Link className="brand" href="/" onClick={closeDrawer}>
+          <span className="brand-mark" aria-hidden="true">
+            SI
+          </span>
+          <span className="brand-copy">
+            <strong>StellarInsure</strong>
+            <span>Parametric cover on Stellar</span>
+          </span>
+        </Link>
+
+        <button
+          type="button"
+          className="mobile-nav-toggle"
+          aria-expanded={drawerOpen}
+          aria-controls="mobile-nav-drawer"
+          onClick={() => setDrawerOpen((open) => !open)}
+        >
+          {drawerOpen ? "Close menu" : "Open menu"}
+        </button>
+
+        <nav className="nav-links nav-links--desktop" aria-label="Section navigation">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={pathname === item.href ? "page" : undefined}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="topbar-actions topbar-actions--desktop">
+          <WalletConnectionButton />
+          <LanguageSwitcher />
+        </div>
+      </header>
+
+      <div className={`mobile-drawer-backdrop ${drawerOpen ? "is-open" : ""}`} onClick={closeDrawer} />
+      <aside
+        id="mobile-nav-drawer"
+        className={`mobile-drawer ${drawerOpen ? "is-open" : ""}`}
+        aria-hidden={!drawerOpen}
+      >
+        <nav className="mobile-drawer__links" aria-label="Mobile section navigation">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={pathname === item.href ? "page" : undefined}
+              onClick={closeDrawer}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="mobile-drawer__actions">
+          <WalletConnectionButton />
+          <LanguageSwitcher />
+        </div>
+      </aside>
+
+      <section className="page-context motion-panel" aria-label="Current page context">
+        <h2>{context.title}</h2>
+        <p>{context.description}</p>
+      </section>
+    </>
+  );
+}

--- a/smartcontract/Cargo.toml
+++ b/smartcontract/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "21.0.0" }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+proptest = "1"
 
 [profile.release]
 opt-level = "z"

--- a/smartcontract/src/fuzz_tests.rs
+++ b/smartcontract/src/fuzz_tests.rs
@@ -3,6 +3,7 @@
 use crate::{
     PolicyStatus, PolicyType, RiskPool, RiskPoolClient, StellarInsure, StellarInsureClient,
 };
+use proptest::prelude::*;
 use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
 
 const ONE_XLM: i128 = 10_000_000;
@@ -27,6 +28,16 @@ fn rand_i128(state: &mut u64, min: i128, max: i128) -> i128 {
 
 fn random_policy_type(state: &mut u64) -> PolicyType {
     match next_u64(state) % 5 {
+        0 => PolicyType::Weather,
+        1 => PolicyType::SmartContract,
+        2 => PolicyType::Flight,
+        3 => PolicyType::Health,
+        _ => PolicyType::Asset,
+    }
+}
+
+fn policy_type_from_index(idx: u8) -> PolicyType {
+    match idx % 5 {
         0 => PolicyType::Weather,
         1 => PolicyType::SmartContract,
         2 => PolicyType::Flight,
@@ -228,5 +239,69 @@ fn fuzz_claim_submission_above_coverage_rejected() {
         let result =
             client.try_submit_claim(&policy_id, &too_large, &String::from_str(&env, "proof"));
         assert!(result.is_err(), "claim above coverage must fail");
+    }
+}
+
+proptest! {
+    #[test]
+    fn proptest_policy_creation_accepts_valid_inputs(
+        policy_type_idx in 0u8..5u8,
+        coverage in 1i128..(ONE_XLM * 1_000_000),
+        duration in 1u64..(365u64 * 24 * 3600 * 5),
+    ) {
+        let (env, contract_id, _admin, policyholder) = setup_insurance_contract();
+        let client = StellarInsureClient::new(&env, &contract_id);
+        let policy_type = policy_type_from_index(policy_type_idx);
+        let premium = client.calculate_premium(&policy_type, &coverage, &duration);
+
+        let created_id = client.create_policy(
+            &policyholder,
+            &policy_type,
+            &coverage,
+            &premium,
+            &duration,
+            &String::from_str(&env, "proptest-create"),
+        );
+
+        let stored = client.get_policy(&created_id);
+        prop_assert_eq!(stored.policyholder, policyholder);
+        prop_assert_eq!(stored.coverage_amount, coverage);
+        prop_assert_eq!(stored.status, PolicyStatus::Active);
+    }
+
+    #[test]
+    fn proptest_claim_amounts_stay_within_policy_bounds(
+        coverage in 1i128..(ONE_XLM * 300_000),
+        duration in 60u64..(365u64 * 24 * 3600),
+        claim_amount in 1i128..(ONE_XLM * 300_000),
+    ) {
+        let (env, contract_id, _admin, policyholder) = setup_insurance_contract();
+        let client = StellarInsureClient::new(&env, &contract_id);
+        let premium = client.calculate_premium(&PolicyType::Weather, &coverage, &duration);
+
+        let policy_id = client.create_policy(
+            &policyholder,
+            &PolicyType::Weather,
+            &coverage,
+            &premium,
+            &duration,
+            &String::from_str(&env, "proptest-claim"),
+        );
+
+        if claim_amount <= coverage {
+            let submit_result = client.try_submit_claim(
+                &policy_id,
+                &claim_amount,
+                &String::from_str(&env, "proof"),
+            );
+            prop_assert!(submit_result.is_ok());
+        } else {
+            let submit_result = client.try_submit_claim(
+                &policy_id,
+                &claim_amount,
+                &String::from_str(&env, "proof"),
+            );
+            prop_assert!(submit_result.is_err());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add GitHub contribution templates (bug report, feature request, template chooser config, and PR checklist template) with default labels for issue auto-labeling
- implement a reusable global header with responsive desktop navigation, a mobile drawer, and contextual page header metadata rendered across app pages
- add frontend page-level tests for `history-page-client` and `create-page-client`, mocking wallet/signing and covering filter/pagination/expand plus step/submission flows
- extend smart contract fuzzing by introducing `proptest`-based property tests for policy creation and claim boundaries

## Issue coverage
- Closes #226
- Closes #219
- Closes #66
- Closes #31

## Validation
- `cd frontend && npm test -- --run src/app/history/history-page-client.test.tsx src/app/create/create-page-client.test.tsx`
- `cd smartcontract && cargo test fuzz_ -- --nocapture && cargo test proptest_ -- --nocapture`

Made with [Cursor](https://cursor.com)