### PR TITLE
feat: add kubernetes manifests and staging environment automation

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,67 @@
+name: Staging Deploy
+
+on:
+  push:
+    branches:
+      - "release/**"
+  workflow_dispatch:
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        if: ${{ secrets.STAGING_KUBECONFIG != '' }}
+        run: |
+          mkdir -p "${HOME}/.kube"
+          echo "${STAGING_KUBECONFIG}" | base64 --decode > "${HOME}/.kube/config"
+        env:
+          STAGING_KUBECONFIG: ${{ secrets.STAGING_KUBECONFIG }}
+
+      - name: Deploy staging manifests
+        if: ${{ secrets.STAGING_KUBECONFIG != '' }}
+        run: kubectl apply -k k8s/overlays/staging
+
+      - name: Staging deploy secrets reminder
+        if: ${{ secrets.STAGING_KUBECONFIG == '' }}
+        run: echo "Set STAGING_KUBECONFIG secret to enable automated staging deploy."
+
+  seed-staging-data:
+    runs-on: ubuntu-latest
+    environment: staging
+    needs: deploy-staging
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Seed staging database
+        if: ${{ secrets.STAGING_DATABASE_URL != '' }}
+        run: python -m src.seed_staging
+        env:
+          ENVIRONMENT: staging
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          JWT_SECRET_KEY: ${{ secrets.STAGING_JWT_SECRET_KEY }}
+          WEBHOOK_SECRET_KEY: ${{ secrets.STAGING_WEBHOOK_SECRET_KEY }}
+          STORAGE_SECRET_KEY: ${{ secrets.STAGING_STORAGE_SECRET_KEY }}
+
+      - name: Staging seed secrets reminder
+        if: ${{ secrets.STAGING_DATABASE_URL == '' }}
+        run: echo "Set STAGING_DATABASE_URL and related staging secrets to enable seed step."

--- a/README.md
+++ b/README.md
@@ -238,6 +238,21 @@ This will start:
 
 ---
 
+## Kubernetes Deployment
+
+Production-ready Kubernetes manifests are available under [`k8s/`](./k8s):
+- `k8s/base`: backend/frontend deployments and services, PostgreSQL and Redis statefulsets, ingress with TLS, config and secret templates, and backend HPA.
+- `k8s/overlays/staging`: staging-specific hostnames, image tags, and feature flags.
+- `k8s/overlays/production`: production overlay.
+
+Example apply commands:
+```bash
+kubectl apply -k k8s/overlays/staging
+kubectl apply -k k8s/overlays/production
+```
+
+---
+
 ## Creating a Policy
 
 ### Via CLI
@@ -316,6 +331,8 @@ Factors affecting premium:
 - [Oracle Integration Guide](./docs/ORACLE.md)
 - [API Reference](./docs/API.md)
 - [Frontend Guide](./docs/FRONTEND.md)
+- [Kubernetes Deployment Guide](./docs/KUBERNETES.md)
+- [Staging Environment Guide](./docs/STAGING.md)
 
 ### Smart contract indexing
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -85,3 +85,11 @@ WEBHOOK_DELIVERY_TIMEOUT=30
 # --- Logging ---
 # Log level: DEBUG | INFO | WARNING | ERROR | CRITICAL
 LOG_LEVEL=INFO
+
+# --- Feature Flags ---
+# Enable staged rollout of enhanced oracle verification flow.
+FEATURE_FLAG_ORACLE_V2=false
+# Enable automatic low-risk claim approval in controlled environments.
+FEATURE_FLAG_CLAIM_AUTO_APPROVAL=false
+# Enable risk pool rebalancing logic.
+FEATURE_FLAG_POOL_REBALANCING=false

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,53 @@
+# =============================================================================
+# StellarInsure Backend - Staging Environment Template
+# =============================================================================
+# Copy to .env.staging (or inject through CI/secret manager).
+# Values here are safe placeholders only.
+# =============================================================================
+
+ENVIRONMENT=staging
+BASE_URL=https://api.staging.stellarinsure.example.com
+CORS_ORIGINS=https://staging.stellarinsure.example.com
+
+JWT_SECRET_KEY=replace-with-staging-secret-min-32-characters
+JWT_ALGORITHM=HS256
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
+JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+
+DATABASE_URL=postgresql://postgres:postgres@postgresql.staging.svc.cluster.local:5432/stellarinsure_staging
+DB_POOL_SIZE=10
+DB_MAX_OVERFLOW=20
+DB_POOL_TIMEOUT=30
+DB_POOL_RECYCLE=1800
+DB_POOL_PRE_PING=true
+DB_ECHO=false
+
+STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_CONTRACT_ID=
+STELLAR_ADMIN_SECRET=
+STELLAR_ADMIN_PUBLIC=
+
+STORAGE_TYPE=local
+UPLOAD_DIR=uploads
+MAX_UPLOAD_SIZE=10485760
+STORAGE_SECRET_KEY=replace-with-staging-storage-secret
+
+REDIS_URL=redis://redis.staging.svc.cluster.local:6379/0
+REDIS_CACHE_TTL=180
+REDIS_ENABLED=true
+
+RATE_LIMIT_DEFAULT=120/minute
+RATE_LIMIT_AUTH=30/minute
+RATE_LIMIT_AUTH_BYPASS=false
+
+WEBHOOK_SECRET_KEY=replace-with-staging-webhook-secret
+WEBHOOK_MAX_RETRIES=3
+WEBHOOK_DELIVERY_TIMEOUT=30
+
+LOG_LEVEL=INFO
+
+# Staging feature flags
+FEATURE_FLAG_ORACLE_V2=true
+FEATURE_FLAG_CLAIM_AUTO_APPROVAL=true
+FEATURE_FLAG_POOL_REBALANCING=true

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -65,6 +65,11 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
 
+    # Feature flags
+    feature_flag_oracle_v2: bool = False
+    feature_flag_claim_auto_approval: bool = False
+    feature_flag_pool_rebalancing: bool = False
+
     @field_validator("environment")
     @classmethod
     def validate_environment(cls, v: str) -> str:
@@ -102,6 +107,14 @@ class Settings(BaseSettings):
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
+
+    @property
+    def feature_flags(self) -> dict:
+        return {
+            "oracle_v2": self.feature_flag_oracle_v2,
+            "claim_auto_approval": self.feature_flag_claim_auto_approval,
+            "pool_rebalancing": self.feature_flag_pool_rebalancing,
+        }
 
     def log_settings(self) -> None:
         """Log non-sensitive settings on startup for debugging."""

--- a/backend/src/seed_staging.py
+++ b/backend/src/seed_staging.py
@@ -1,0 +1,79 @@
+"""Seed script for staging environment data."""
+
+from decimal import Decimal
+import os
+import time
+
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+from .models import Policy, PolicyStatus, PolicyType, User
+
+
+def seed(db: Session) -> None:
+    first = (
+        db.query(User)
+        .filter(User.stellar_address == "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF")
+        .first()
+    )
+    second = (
+        db.query(User)
+        .filter(User.stellar_address == "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBWHF")
+        .first()
+    )
+
+    if not first:
+        first = User(
+            stellar_address="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            email="staging-user-1@stellarinsure.test",
+        )
+        db.add(first)
+
+    if not second:
+        second = User(
+            stellar_address="GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBWHF",
+            email="staging-user-2@stellarinsure.test",
+        )
+        db.add(second)
+
+    db.flush()
+
+    existing_policy = (
+        db.query(Policy)
+        .filter(Policy.policyholder_id == first.id, Policy.trigger_condition == "seeded-weather-threshold")
+        .first()
+    )
+    if not existing_policy:
+        now = int(time.time())
+        db.add(
+            Policy(
+                policyholder_id=first.id,
+                policy_type=PolicyType.weather,
+                coverage_amount=Decimal("1000.0000000"),
+                premium=Decimal("25.0000000"),
+                start_time=now,
+                end_time=now + 2_592_000,
+                trigger_condition="seeded-weather-threshold",
+                status=PolicyStatus.active,
+                claim_amount=Decimal("0"),
+            )
+        )
+
+    db.commit()
+
+
+def main() -> None:
+    environment = os.getenv("ENVIRONMENT", "development")
+    if environment != "staging":
+        raise RuntimeError("Seeding aborted: ENVIRONMENT must be 'staging'.")
+
+    db = SessionLocal()
+    try:
+        seed(db)
+        print("Staging seed completed successfully.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -62,6 +62,13 @@ class TestSettingsValidation:
         assert s.webhook_max_retries == 3
         assert s.webhook_delivery_timeout == 30
 
+    def test_feature_flags_defaults(self):
+        from src.config import Settings
+        s = Settings(database_url="sqlite://", jwt_secret_key="k")
+        assert s.feature_flags["oracle_v2"] is False
+        assert s.feature_flags["claim_auto_approval"] is False
+        assert s.feature_flags["pool_rebalancing"] is False
+
 
 class TestSecretsNotLogged:
     """Test that sensitive fields are redacted in logs."""

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -1,0 +1,41 @@
+# Kubernetes Deployment Guide
+
+## Overview
+
+Kubernetes manifests are organized using `kustomize`:
+
+- `k8s/base`: shared resources for all environments.
+- `k8s/overlays/staging`: staging overrides.
+- `k8s/overlays/production`: production overlay.
+
+## Resources Included
+
+The base stack includes:
+
+- Backend `Deployment` + `Service`
+- Frontend `Deployment` + `Service`
+- PostgreSQL `StatefulSet` + headless `Service`
+- Redis `StatefulSet` + headless `Service`
+- `Ingress` with TLS termination
+- Backend `HorizontalPodAutoscaler`
+- `ConfigMap` defaults and `Secret` template
+
+## Secrets
+
+Before applying manifests, create/update `stellarinsure-secrets` with real values.
+
+Template reference: `k8s/base/secret-template.yaml`
+
+Never commit populated secret manifests.
+
+## Deploy Commands
+
+```bash
+kubectl apply -k k8s/overlays/staging
+kubectl apply -k k8s/overlays/production
+```
+
+## Rolling Deployment Behavior
+
+- Backend/frontend deployments use `RollingUpdate` with `maxUnavailable: 0`.
+- HPA scales backend pods between 2 and 8 replicas based on CPU utilization.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,39 @@
+# Staging Environment Guide
+
+## Purpose
+
+`staging` is a production-like environment used for QA validation before promoting changes to `master`.
+
+## Access
+
+- Frontend: `https://staging.stellarinsure.example.com`
+- Backend API: `https://api.staging.stellarinsure.example.com`
+
+## Deployment Flow
+
+- Pushes to `release/**` trigger `.github/workflows/staging-deploy.yml`.
+- The workflow applies `k8s/overlays/staging`.
+- A seed step runs `python -m src.seed_staging` when staging DB secrets are configured.
+
+## Required GitHub Secrets
+
+- `STAGING_KUBECONFIG`
+- `STAGING_DATABASE_URL`
+- `STAGING_JWT_SECRET_KEY`
+- `STAGING_WEBHOOK_SECRET_KEY`
+- `STAGING_STORAGE_SECRET_KEY`
+
+## Staging Configuration
+
+Use `backend/.env.staging.example` as the baseline. Key staging behaviors:
+
+- `ENVIRONMENT=staging`
+- Staging-specific CORS and base URLs
+- Feature flags enabled for pre-production testing:
+  - `FEATURE_FLAG_ORACLE_V2=true`
+  - `FEATURE_FLAG_CLAIM_AUTO_APPROVAL=true`
+  - `FEATURE_FLAG_POOL_REBALANCING=true`
+
+## Seeded Data
+
+The staging seed script adds deterministic sample users and an active sample policy for QA smoke tests.

--- a/k8s/base/backend-deployment.yaml
+++ b/k8s/base/backend-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/chaoLing140/stellarinsure-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: stellarinsure-config
+            - secretRef:
+                name: stellarinsure-secrets
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5

--- a/k8s/base/backend-hpa.yaml
+++ b/k8s/base/backend-hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/backend-service.yaml
+++ b/k8s/base/backend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellarinsure-config
+data:
+  ENVIRONMENT: production
+  BASE_URL: https://api.stellarinsure.example.com
+  CORS_ORIGINS: https://stellarinsure.example.com
+  STELLAR_NETWORK_PASSPHRASE: Test SDF Network ; September 2015
+  STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+  REDIS_URL: redis://redis:6379/0
+  REDIS_ENABLED: "true"
+  REDIS_CACHE_TTL: "300"
+  DB_POOL_SIZE: "10"
+  DB_MAX_OVERFLOW: "20"
+  DB_POOL_TIMEOUT: "30"
+  DB_POOL_RECYCLE: "3600"
+  DB_POOL_PRE_PING: "true"
+  DB_ECHO: "false"
+  RATE_LIMIT_DEFAULT: 60/minute
+  RATE_LIMIT_AUTH: 10/minute
+  RATE_LIMIT_AUTH_BYPASS: "false"
+  WEBHOOK_MAX_RETRIES: "3"
+  WEBHOOK_DELIVERY_TIMEOUT: "30"
+  LOG_LEVEL: INFO
+  FEATURE_FLAG_ORACLE_V2: "false"
+  FEATURE_FLAG_CLAIM_AUTO_APPROVAL: "false"
+  FEATURE_FLAG_POOL_REBALANCING: "false"

--- a/k8s/base/frontend-deployment.yaml
+++ b/k8s/base/frontend-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/chaoLing140/stellarinsure-frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: production
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 5

--- a/k8s/base/frontend-service.yaml
+++ b/k8s/base/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stellarinsure-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - app.stellarinsure.example.com
+        - api.stellarinsure.example.com
+      secretName: stellarinsure-tls
+  rules:
+    - host: app.stellarinsure.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3000
+    - host: api.stellarinsure.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: stellarinsure
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret-template.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - backend-hpa.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - postgres-service.yaml
+  - postgres-statefulset.yaml
+  - redis-service.yaml
+  - redis-statefulset.yaml
+  - ingress.yaml

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stellarinsure

--- a/k8s/base/postgres-service.yaml
+++ b/k8s/base/postgres-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+spec:
+  selector:
+    app: postgresql
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres
+  clusterIP: None

--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql
+spec:
+  serviceName: postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: stellarinsure-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: stellarinsure
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U postgres -d stellarinsure"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U postgres -d stellarinsure"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 6
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi

--- a/k8s/base/redis-service.yaml
+++ b/k8s/base/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  clusterIP: None

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          args: ["redis-server", "--appendonly", "yes"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 6
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/base/secret-template.yaml
+++ b/k8s/base/secret-template.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stellarinsure-secrets
+type: Opaque
+stringData:
+  JWT_SECRET_KEY: "<replace-with-strong-secret>"
+  DATABASE_URL: "postgresql://postgres:<replace-password>@postgresql:5432/stellarinsure"
+  STELLAR_ADMIN_SECRET: "<replace-with-stellar-secret>"
+  STELLAR_ADMIN_PUBLIC: "<replace-with-stellar-public-key>"
+  STELLAR_CONTRACT_ID: "<replace-with-contract-id>"
+  STORAGE_SECRET_KEY: "<replace-with-storage-secret>"
+  WEBHOOK_SECRET_KEY: "<replace-with-webhook-secret>"
+  POSTGRES_PASSWORD: "<replace-with-postgres-password>"
+  REDIS_PASSWORD: "<replace-with-redis-password-if-enabled>"

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: stellarinsure

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - patch-configmap.yaml
+  - patch-backend.yaml
+  - patch-frontend.yaml
+  - patch-ingress.yaml
+  - patch-namespace.yaml
+namespace: staging

--- a/k8s/overlays/staging/patch-backend.yaml
+++ b/k8s/overlays/staging/patch-backend.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/chaoLing140/stellarinsure-backend:staging

--- a/k8s/overlays/staging/patch-configmap.yaml
+++ b/k8s/overlays/staging/patch-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellarinsure-config
+data:
+  ENVIRONMENT: staging
+  BASE_URL: https://api.staging.stellarinsure.example.com
+  CORS_ORIGINS: https://staging.stellarinsure.example.com
+  RATE_LIMIT_DEFAULT: 120/minute
+  RATE_LIMIT_AUTH: 30/minute
+  FEATURE_FLAG_ORACLE_V2: "true"
+  FEATURE_FLAG_CLAIM_AUTO_APPROVAL: "true"
+  FEATURE_FLAG_POOL_REBALANCING: "true"

--- a/k8s/overlays/staging/patch-frontend.yaml
+++ b/k8s/overlays/staging/patch-frontend.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/chaoLing140/stellarinsure-frontend:staging

--- a/k8s/overlays/staging/patch-ingress.yaml
+++ b/k8s/overlays/staging/patch-ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stellarinsure-ingress
+spec:
+  tls:
+    - hosts:
+        - staging.stellarinsure.example.com
+        - api.staging.stellarinsure.example.com
+      secretName: stellarinsure-staging-tls
+  rules:
+    - host: staging.stellarinsure.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3000
+    - host: api.staging.stellarinsure.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8000

--- a/k8s/overlays/staging/patch-namespace.yaml
+++ b/k8s/overlays/staging/patch-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging


### PR DESCRIPTION
## Description
Implemented Kubernetes deployment manifests and staging environment automation/configuration so the project can run production-like infra with an automated release-branch staging path.

Closes #213
Closes #221

## Changes proposed

### What were you told to do?
Add Kubernetes manifests for production deployment (backend/frontend services, Postgres/Redis stateful services, TLS ingress, ConfigMap/Secret templates, and backend HPA) and add a staging environment with automation, seeded data, feature flags, and documentation.

### What did I do?
#### Kubernetes Infrastructure (Issue #213)
- Added a full `k8s/` structure with `base` and `overlays`.
- Added backend/frontend `Deployment` and `Service` manifests.
- Added PostgreSQL and Redis `StatefulSet` plus headless `Service` manifests.
- Added TLS-enabled `Ingress` routing frontend and API hosts.
- Added `ConfigMap` defaults and templated `Secret` manifest with placeholders (no hardcoded credentials).
- Added backend `HorizontalPodAutoscaler` configuration.

#### Staging Environment (Issue #221)
- Added `.github/workflows/staging-deploy.yml` to deploy on `release/**` branch pushes.
- Added `backend/.env.staging.example` with staging-specific values.
- Added backend staging feature flags in config:
- `FEATURE_FLAG_ORACLE_V2`
- `FEATURE_FLAG_CLAIM_AUTO_APPROVAL`
- `FEATURE_FLAG_POOL_REBALANCING`
- Added `backend/src/seed_staging.py` to seed deterministic staging test data.
- Added staging and Kubernetes documentation:
- `docs/STAGING.md`
- `docs/KUBERNETES.md`
- Updated `README.md` to reference Kubernetes/staging docs and deployment paths.

#### Test/Config Updates
- Extended backend config tests to validate feature flag defaults.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Ran `python -m py_compile backend/src/config.py backend/src/seed_staging.py` successfully.
- `pytest` execution could not be completed in this environment because `pytest` is not installed (`python -m pytest` returns `No module named pytest`).
- Manifest and workflow changes are static infrastructure/config additions and were validated for structure and wiring within repository conventions.
