### PR TITLE
test: add webhook dispatch integration tests

### DIFF
--- a/backend/src/routes/claims.py
+++ b/backend/src/routes/claims.py
@@ -1,4 +1,5 @@
 from datetime import datetime as dt
+import logging
 from fastapi import APIRouter, Depends, status, Query, UploadFile, File, Form
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -19,8 +20,10 @@ from ..errors import (
     ClaimNotFoundError
 )
 from ..services.storage_service import storage_service
+from ..services.webhook_service import dispatch_webhook_event
 
 router = APIRouter(prefix="/claims", tags=["claims"])
+logger = logging.getLogger(__name__)
 
 def format_claim_response(claim: Claim) -> ClaimResponse:
     proof = claim.proof
@@ -91,6 +94,21 @@ async def create_claim(
     db.commit()
     db.refresh(claim)
 
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type="claim.created",
+            payload={
+                "claim_id": claim.id,
+                "policy_id": claim.policy_id,
+                "claim_amount": float(claim.claim_amount),
+                "approved": claim.approved,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch claim.created webhook for claim_id=%s", claim.id)
+
     return format_claim_response(claim)
 
 
@@ -145,6 +163,21 @@ async def create_claim_with_file(
     db.add(claim)
     db.commit()
     db.refresh(claim)
+
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type="claim.created",
+            payload={
+                "claim_id": claim.id,
+                "policy_id": claim.policy_id,
+                "claim_amount": float(claim.claim_amount),
+                "approved": claim.approved,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch claim.created webhook for claim_id=%s", claim.id)
 
     return format_claim_response(claim)
 
@@ -268,6 +301,23 @@ async def update_claim_status(
 
     db.commit()
     db.refresh(claim)
+
+    event_type = "claim.approved" if approved else "claim.rejected"
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type=event_type,
+            payload={
+                "claim_id": claim.id,
+                "policy_id": claim.policy_id,
+                "claim_amount": float(claim.claim_amount),
+                "approved": claim.approved,
+                "policy_status": policy.status.value if policy else None,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch %s webhook for claim_id=%s", event_type, claim.id)
 
     return format_claim_response(claim)
 

--- a/backend/src/routes/policies.py
+++ b/backend/src/routes/policies.py
@@ -1,3 +1,4 @@
+import logging
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -19,8 +20,10 @@ from ..errors import (
     PolicyNotEligibleForClaimError
 )
 from ..cache import cache_get, cache_set, invalidate_policy_cache
+from ..services.webhook_service import dispatch_webhook_event
 
 router = APIRouter(prefix="/policies", tags=["policies"])
+logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -59,6 +62,22 @@ async def create_policy(
     db.refresh(policy)
     
     invalidate_policy_cache(current_user.id)
+
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type="policy.created",
+            payload={
+                "policy_id": policy.id,
+                "policy_type": policy.policy_type.value,
+                "status": policy.status.value,
+                "coverage_amount": float(policy.coverage_amount),
+                "premium": float(policy.premium),
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch policy.created webhook for policy_id=%s", policy.id)
     
     return PolicyResponse(
         id=policy.id,
@@ -214,6 +233,19 @@ async def cancel_policy(
     db.commit()
     
     invalidate_policy_cache(current_user.id)
+
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type="policy.cancelled",
+            payload={
+                "policy_id": policy.id,
+                "status": policy.status.value,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch policy.cancelled webhook for policy_id=%s", policy.id)
     
     return MessageResponse(message="Policy cancelled successfully")
 
@@ -264,6 +296,21 @@ async def submit_claim(
     db.add(claim)
     db.commit()
     db.refresh(claim)
+
+    try:
+        dispatch_webhook_event(
+            db=db,
+            user_id=current_user.id,
+            event_type="claim.created",
+            payload={
+                "claim_id": claim.id,
+                "policy_id": claim.policy_id,
+                "claim_amount": float(claim.claim_amount),
+                "approved": claim.approved,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to dispatch claim.created webhook for claim_id=%s", claim.id)
     
     return ClaimResponse(
         id=claim.id,

--- a/backend/tests/test_webhook_dispatch_integration.py
+++ b/backend/tests/test_webhook_dispatch_integration.py
@@ -1,0 +1,242 @@
+"""Integration tests for end-to-end webhook dispatch flow (Issue #224)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.models import Webhook, WebhookDelivery
+from src.services import webhook_service
+
+
+def _now() -> int:
+    return int(datetime.utcnow().timestamp())
+
+
+def _create_policy(client, headers: dict) -> dict:
+    now = _now()
+    response = client.post(
+        "/policies/",
+        headers=headers,
+        json={
+            "policy_type": "weather",
+            "coverage_amount": 1000.0,
+            "premium": 25.0,
+            "start_time": now,
+            "end_time": now + 86_400,
+            "trigger_condition": "rainfall > 100mm",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def _create_webhook(client, headers: dict, event_types: list[str]) -> int:
+    response = client.post(
+        "/webhooks/",
+        headers=headers,
+        json={
+            "url": "https://mocked-webhook.local/endpoint",
+            "event_types": event_types,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+class _SuccessClient:
+    """Mocked HTTP client that always returns success and captures request data."""
+
+    calls: list[dict] = []
+
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, content=None, headers=None):
+        self.__class__.calls.append(
+            {
+                "url": url,
+                "content": content,
+                "headers": headers or {},
+            }
+        )
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "OK"
+        return response
+
+
+class _FailingClient:
+    """Mocked HTTP client that always fails with 500 and tracks attempts."""
+
+    calls: int = 0
+
+    def __init__(self, timeout=None):
+        self.timeout = timeout
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, content=None, headers=None):
+        self.__class__.calls += 1
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "Server Error"
+        return response
+
+
+def test_policy_creation_dispatches_webhook_with_valid_signature(
+    client, auth_headers, db_session, monkeypatch
+):
+    _SuccessClient.calls = []
+    monkeypatch.setattr("src.services.webhook_service.httpx.Client", _SuccessClient)
+
+    webhook_id = _create_webhook(client, auth_headers, ["policy.created"])
+    _create_policy(client, auth_headers)
+
+    delivery = (
+        db_session.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(Webhook.id == webhook_id, WebhookDelivery.event_type == "policy.created")
+        .first()
+    )
+    assert delivery is not None
+    assert delivery.success is True
+
+    assert len(_SuccessClient.calls) == 1
+    call = _SuccessClient.calls[0]
+    assert call["headers"]["X-Webhook-Event"] == "policy.created"
+
+    webhook = db_session.get(Webhook, webhook_id)
+    assert webhook_service.verify_webhook_signature(
+        call["content"],
+        call["headers"]["X-Webhook-Signature"],
+        webhook.secret,
+    )
+
+
+def test_claim_submission_dispatches_webhook(client, auth_headers, db_session, monkeypatch):
+    _SuccessClient.calls = []
+    monkeypatch.setattr("src.services.webhook_service.httpx.Client", _SuccessClient)
+
+    webhook_id = _create_webhook(client, auth_headers, ["claim.created"])
+    policy = _create_policy(client, auth_headers)
+
+    response = client.post(
+        "/claims/",
+        headers=auth_headers,
+        json={
+            "policy_id": policy["id"],
+            "claim_amount": 120.0,
+            "proof": "sensor proof",
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    delivery = (
+        db_session.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(Webhook.id == webhook_id, WebhookDelivery.event_type == "claim.created")
+        .first()
+    )
+    assert delivery is not None
+    assert delivery.success is True
+    assert len(_SuccessClient.calls) >= 1
+    assert any(c["headers"]["X-Webhook-Event"] == "claim.created" for c in _SuccessClient.calls)
+
+
+@pytest.mark.parametrize(
+    ("approved", "expected_event"),
+    [
+        (True, "claim.approved"),
+        (False, "claim.rejected"),
+    ],
+)
+def test_claim_processing_dispatches_webhook_event_types(
+    client, auth_headers, db_session, monkeypatch, approved, expected_event
+):
+    _SuccessClient.calls = []
+    monkeypatch.setattr("src.services.webhook_service.httpx.Client", _SuccessClient)
+
+    webhook_id = _create_webhook(client, auth_headers, [expected_event])
+    policy = _create_policy(client, auth_headers)
+
+    claim_resp = client.post(
+        "/claims/",
+        headers=auth_headers,
+        json={
+            "policy_id": policy["id"],
+            "claim_amount": 100.0,
+            "proof": "processing proof",
+        },
+    )
+    assert claim_resp.status_code == 201, claim_resp.text
+    claim_id = claim_resp.json()["id"]
+
+    process_resp = client.patch(
+        f"/claims/{claim_id}?approved={'true' if approved else 'false'}",
+        headers=auth_headers,
+    )
+    assert process_resp.status_code == 200, process_resp.text
+
+    delivery = (
+        db_session.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(Webhook.id == webhook_id, WebhookDelivery.event_type == expected_event)
+        .first()
+    )
+    assert delivery is not None
+    assert delivery.success is True
+    assert any(c["headers"]["X-Webhook-Event"] == expected_event for c in _SuccessClient.calls)
+
+
+def test_policy_cancellation_dispatches_webhook(client, auth_headers, db_session, monkeypatch):
+    _SuccessClient.calls = []
+    monkeypatch.setattr("src.services.webhook_service.httpx.Client", _SuccessClient)
+
+    webhook_id = _create_webhook(client, auth_headers, ["policy.cancelled"])
+    policy = _create_policy(client, auth_headers)
+
+    cancel_resp = client.delete(f"/policies/{policy['id']}", headers=auth_headers)
+    assert cancel_resp.status_code == 200, cancel_resp.text
+
+    delivery = (
+        db_session.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(Webhook.id == webhook_id, WebhookDelivery.event_type == "policy.cancelled")
+        .first()
+    )
+    assert delivery is not None
+    assert delivery.success is True
+
+
+def test_webhook_retry_behavior_on_failed_delivery(
+    client, auth_headers, db_session, monkeypatch
+):
+    _FailingClient.calls = 0
+    monkeypatch.setattr("src.services.webhook_service.httpx.Client", _FailingClient)
+
+    webhook_id = _create_webhook(client, auth_headers, ["policy.created"])
+    _create_policy(client, auth_headers)
+
+    delivery = (
+        db_session.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(Webhook.id == webhook_id, WebhookDelivery.event_type == "policy.created")
+        .first()
+    )
+    assert delivery is not None
+    assert delivery.success is False
+    assert delivery.attempts == webhook_service.settings.webhook_max_retries
+    assert _FailingClient.calls == webhook_service.settings.webhook_max_retries


### PR DESCRIPTION
## Description
Added backend webhook dispatch integration coverage and route wiring so webhook dispatch is exercised end-to-end for policy and claim lifecycle events.

Closes #224

## Changes proposed

### What were you told to do?
Add integration tests for webhook dispatch across policy creation, claim submission, and claim processing; verify retry behavior and webhook signature validation; use mocked HTTP endpoints.

### What did I do?
#### Route Wiring for Dispatch
- Wired `dispatch_webhook_event` into:
- `POST /policies/` -> `policy.created`
- `DELETE /policies/{id}` -> `policy.cancelled`
- `POST /claims/` and `POST /claims/upload` -> `claim.created`
- `PATCH /claims/{id}` -> `claim.approved` or `claim.rejected`
- Wrapped dispatch calls with non-blocking exception handling so core API operations are not failed by outbound webhook delivery issues.

#### Integration Tests
- Added `backend/tests/test_webhook_dispatch_integration.py` with mocked HTTP client dispatch tests for:
- policy creation dispatch
- claim submission dispatch
- claim processing dispatch (`approved` and `rejected`)
- retry behavior on failed deliveries
- webhook signature verification via captured payload/signature headers
- policy cancellation dispatch coverage

#### Existing Webhook Tests
- Verified compatibility with existing webhook tests in `backend/tests/test_webhooks.py`.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Ran:
- `python -m pytest backend/tests/test_webhook_dispatch_integration.py backend/tests/test_webhooks.py -q`
- Result: `26 passed`.