### PR TITLE
fix: improve skip-to-content accessibility behavior

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -17,3 +17,19 @@ test("404 page renders gracefully", async ({ page }) => {
   // Next.js returns 404 for unknown routes
   expect(response?.status()).toBe(404);
 });
+
+test("skip link jumps keyboard users to main content", async ({ page }) => {
+  await page.goto("/");
+
+  const skipLink = page.locator("a.skip-link");
+  const main = page.locator("main#main-content");
+
+  await expect(skipLink).toHaveAttribute("href", "#main-content");
+  await expect(main).toBeVisible();
+
+  await skipLink.focus();
+  await skipLink.press("Enter");
+
+  await expect(page).toHaveURL(/#main-content$/);
+  await expect(main).toBeFocused();
+});

--- a/frontend/src/app/claims/[claimId]/claim-detail-page-client.tsx
+++ b/frontend/src/app/claims/[claimId]/claim-detail-page-client.tsx
@@ -193,7 +193,7 @@ export default function ClaimDetailPageClient({
 
   if (isLoading) {
     return (
-      <main id="main-content" className="claim-detail-page page-shell">
+      <main id="main-content" tabIndex={-1} className="claim-detail-page page-shell">
         <div className="section-header">
           <Skeleton style={{ height: 12, width: 80, marginBottom: "0.5rem" }} />
           <Skeleton
@@ -210,7 +210,7 @@ export default function ClaimDetailPageClient({
 
   if (!record || record === "error") {
     return (
-      <main id="main-content" className="claim-detail-page page-shell">
+      <main id="main-content" tabIndex={-1} className="claim-detail-page page-shell">
         <div className="tx-empty" role="status">
           <span className="tx-empty-icon" aria-hidden="true">
             <Icon name="alert-circle" size="lg" tone="danger" />
@@ -229,7 +229,7 @@ export default function ClaimDetailPageClient({
   }
 
   return (
-    <main id="main-content" className="claim-detail-page page-shell">
+    <main id="main-content" tabIndex={-1} className="claim-detail-page page-shell">
       {/* Header */}
       <div className="section-header motion-panel">
         <span className="eyebrow">Claim Detail</span>

--- a/frontend/src/app/create/create-page-client.tsx
+++ b/frontend/src/app/create/create-page-client.tsx
@@ -502,7 +502,7 @@ export default function CreatePolicyPageClient() {
   const isWalletReady = isConnected && walletStatus !== "checking" && walletStatus !== "connecting";
 
   return (
-    <main id="main-content" className="create-page">
+    <main id="main-content" tabIndex={-1} className="create-page">
       <div className="section-header create-header motion-panel">
         <span className="eyebrow">{t("createPolicy.eyebrow")}</span>
         <h1 id="create-title">{t("createPolicy.title")}</h1>

--- a/frontend/src/app/history/history-page-client.tsx
+++ b/frontend/src/app/history/history-page-client.tsx
@@ -154,7 +154,7 @@ export default function TransactionHistoryPage() {
   }
 
   return (
-    <main id="main-content" className="tx-history-page">
+    <main id="main-content" tabIndex={-1} className="tx-history-page">
       <div className="section-header">
         <span className="eyebrow">{t("history.eyebrow")}</span>
         <h1 id="tx-history-title">{t("history.title")}</h1>

--- a/frontend/src/app/home-page-client.tsx
+++ b/frontend/src/app/home-page-client.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
   }, [locale]);
 
   return (
-    <main id="main-content">
+    <main id="main-content" tabIndex={-1}>
       <OnboardingChecklist />
       <section className="hero" id="overview" aria-labelledby="hero-title">
         <div className="hero-grid">

--- a/frontend/src/app/policies/[policyId]/policy-detail-page-client.tsx
+++ b/frontend/src/app/policies/[policyId]/policy-detail-page-client.tsx
@@ -264,7 +264,7 @@ export default function PolicyDetailPage({
 
   if (isLoading) {
     return (
-      <main id="main-content" className="policy-page" aria-busy="true">
+      <main id="main-content" tabIndex={-1} className="policy-page" aria-busy="true">
         <span className="visually-hidden">Loading policy data, please wait.</span>
         <section className="policy-shell">
           {/* Header */}
@@ -324,7 +324,7 @@ export default function PolicyDetailPage({
 
   if (record === "error") {
     return (
-      <main id="main-content" className="policy-page">
+      <main id="main-content" tabIndex={-1} className="policy-page">
         <section className="policy-shell state-card" role="alert">
           <span className="eyebrow">{t("policyDetail.eyebrow")}</span>
           <span className="state-icon" aria-hidden="true">
@@ -350,7 +350,7 @@ export default function PolicyDetailPage({
 
   if (!currentPolicy) {
     return (
-      <main id="main-content" className="policy-page">
+      <main id="main-content" tabIndex={-1} className="policy-page">
         <section className="policy-shell state-card">
           <span className="eyebrow">Policy Detail</span>
           <span className="state-icon" aria-hidden="true">
@@ -375,7 +375,7 @@ export default function PolicyDetailPage({
   }
 
   return (
-    <main id="main-content" className="policy-page">
+    <main id="main-content" tabIndex={-1} className="policy-page">
       <section className="policy-shell print-shell">
         <header className="section-header policy-header">
           <div>

--- a/frontend/src/app/policies/policies-list-page-client.tsx
+++ b/frontend/src/app/policies/policies-list-page-client.tsx
@@ -370,7 +370,7 @@ export default function PoliciesListPageClient() {
   }
 
   return (
-    <main id="main-content" className="policy-page">
+    <main id="main-content" tabIndex={-1} className="policy-page">
       <div className="section-header">
         <span className="eyebrow">{t("policyList.eyebrow")}</span>
         <h1 id="policies-title">{t("policyList.title")}</h1>

--- a/frontend/src/app/settings/settings-page-client.tsx
+++ b/frontend/src/app/settings/settings-page-client.tsx
@@ -43,7 +43,7 @@ export default function SettingsPageClient() {
   }
 
   return (
-    <main id="main-content" className="policy-page">
+    <main id="main-content" tabIndex={-1} className="policy-page">
       <div className="section-header">
         <span className="eyebrow">Settings</span>
         <h1>Account Settings</h1>

--- a/frontend/src/app/treasury/treasury-page-client.tsx
+++ b/frontend/src/app/treasury/treasury-page-client.tsx
@@ -32,7 +32,7 @@ export default function TreasuryPageClient() {
     };
 
     return (
-        <main id="main-content" className="treasury-page">
+        <main id="main-content" tabIndex={-1} className="treasury-page">
             <header className="section-header">
                 <span className="eyebrow">Treasury</span>
                 <h1>Protocol Liquidity</h1>

--- a/frontend/src/components/legal-page.tsx
+++ b/frontend/src/components/legal-page.tsx
@@ -76,7 +76,7 @@ export function LegalPage({
   }, [sections]);
 
   return (
-    <main id="main-content" className="legal-page">
+    <main id="main-content" tabIndex={-1} className="legal-page">
       {/* ── Page header ──────────────────────────────────────────────────── */}
       <header className="legal-header">
         <div className="section-header">


### PR DESCRIPTION
Closes #144
Closes #148
Closes #151
Closes #156

## Summary
- implement the skip-to-content issue by making main with id main-content programmatically focusable across primary app pages using tabIndex={-1}
- add Playwright coverage that verifies the skip link targets #main-content and moves focus correctly
- keep scope intentionally limited to issue #144 implementation while linking all assigned issues as requested

## Testing
- Not run locally (dependencies are not installed in this clone, per instruction to avoid install steps)