### PR TITLE
feat: API error boundaries, offline banner, unsaved guard, reduced-motion (#125 #126 #122 #139)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3469,3 +3469,190 @@ dt,
   justify-content: center;
   margin-bottom: 1.5rem;
 }
+
+/* ── ApiErrorBoundary (#125) ─────────────────────────────────────────── */
+.api-error-boundary--section {
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+.api-error-boundary__inner {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  max-width: 28rem;
+}
+.api-error-boundary__heading {
+  font-size: var(--step-2);
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+.api-error-boundary__message {
+  color: var(--text-muted);
+  margin: 0;
+}
+.api-error-boundary__details {
+  width: 100%;
+  text-align: left;
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  font-size: var(--step-0);
+}
+.api-error-boundary__details pre {
+  margin-top: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-danger-500);
+}
+.api-error-boundary__retry-btn {
+  background: var(--color-sky-500);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.api-error-boundary__retry-btn:hover {
+  opacity: 0.9;
+}
+/* card variant */
+.api-error-boundary--card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--color-danger-100);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+/* inline variant */
+.api-error-boundary--inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: var(--step-0);
+  color: var(--color-danger-500);
+}
+.api-error-boundary__retry-link {
+  background: none;
+  border: none;
+  color: var(--color-sky-500);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+/* ── OfflineBanner (#126) ────────────────────────────────────────────── */
+.offline-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  background: var(--color-ink-900);
+  color: var(--color-white);
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: var(--step-0);
+  font-weight: 500;
+}
+.offline-banner--restored {
+  background: var(--color-success-500);
+}
+.offline-banner__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.8;
+  flex-shrink: 0;
+}
+.offline-banner__dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+/* ── UnsavedChangesGuard (#122) ──────────────────────────────────────── */
+.unsaved-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.unsaved-dialog {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  max-width: 28rem;
+  width: 100%;
+  box-shadow: var(--shadow-overlay);
+}
+.unsaved-dialog__heading {
+  font-size: var(--step-2);
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: var(--text);
+}
+.unsaved-dialog__body {
+  color: var(--text-muted);
+  margin: 0 0 1.5rem;
+}
+.unsaved-dialog__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.unsaved-dialog__btn-stay {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text);
+}
+.unsaved-dialog__btn-leave {
+  background: var(--color-danger-500);
+  color: var(--color-white);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* ── Reduced-motion (#139) ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  .page-transition,
+  .motion-panel {
+    animation: none;
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { SiteHeader } from "@/components/site-header";
 import { StructuredData } from "@/components/structured-data";
 import { WalletProvider } from "@/components/wallet-provider";
 import { MaintenanceBanner } from "@/components/maintenance-banner";
+import { OfflineBanner } from "@/components/offline-banner";
 import { OnboardingFlow } from "@/components/onboarding";
 import { OnboardingTooltips } from "@/components/onboarding-tooltips";
 import { PageTransition } from "@/components/page-transition";
@@ -85,6 +86,7 @@ export default function RootLayout({
                 Skip to main content
               </a>
               <div className="page-shell">
+                <OfflineBanner />
                 <MaintenanceBanner />
                 <SiteHeader />
 

--- a/frontend/src/components/api-error-boundary.tsx
+++ b/frontend/src/components/api-error-boundary.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import React, { ErrorInfo, ReactNode, useCallback, useState } from "react";
+import { Icon } from "./icon";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type ApiErrorVariant = "section" | "card" | "inline";
+
+interface ApiErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Display variant:
+   * - `section`  Full-width section replacement (default)
+   * - `card`     Contained card-sized fallback
+   * - `inline`   Single-line inline error for small components
+   */
+  variant?: ApiErrorVariant;
+  /** Optional section label for screen readers. */
+  label?: string;
+  /** Custom fallback rendered instead of the default error UI. */
+  fallback?: (error: Error, retry: () => void) => ReactNode;
+}
+
+interface BoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+// ── Class boundary ─────────────────────────────────────────────────────────
+
+class ApiErrorBoundaryInner extends React.Component<
+  ApiErrorBoundaryProps & { onError?: (e: Error, info: ErrorInfo) => void },
+  BoundaryState
+> {
+  constructor(props: ApiErrorBoundaryProps & { onError?: (e: Error, info: ErrorInfo) => void }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ApiErrorBoundary]", error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  retry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (!this.state.hasError || !this.state.error) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return <>{this.props.fallback(this.state.error, this.retry)}</>;
+    }
+
+    return (
+      <ApiErrorFallback
+        error={this.state.error}
+        variant={this.props.variant ?? "section"}
+        label={this.props.label}
+        onRetry={this.retry}
+      />
+    );
+  }
+}
+
+// ── Fallback UI ────────────────────────────────────────────────────────────
+
+interface FallbackProps {
+  error: Error;
+  variant: ApiErrorVariant;
+  label?: string;
+  onRetry: () => void;
+}
+
+function ApiErrorFallback({ error, variant, label, onRetry }: FallbackProps) {
+  const isApiError = isNetworkOrApiError(error);
+  const message = isApiError
+    ? "We couldn't load this content. Check your connection and try again."
+    : "Something went wrong in this section.";
+
+  if (variant === "inline") {
+    return (
+      <span
+        role="alert"
+        aria-label={label}
+        className="api-error-boundary api-error-boundary--inline"
+      >
+        <Icon name="alert" size="sm" tone="danger" aria-hidden="true" />
+        <span className="api-error-boundary__inline-msg">{message}</span>
+        <button
+          type="button"
+          className="api-error-boundary__retry-link"
+          onClick={onRetry}
+          aria-label="Retry loading this section"
+        >
+          Retry
+        </button>
+      </span>
+    );
+  }
+
+  if (variant === "card") {
+    return (
+      <div
+        role="alert"
+        aria-label={label ?? "Section error"}
+        className="api-error-boundary api-error-boundary--card"
+      >
+        <Icon name="alert" size="md" tone="danger" aria-hidden="true" />
+        <p className="api-error-boundary__message">{message}</p>
+        <button
+          type="button"
+          className="api-error-boundary__retry-btn"
+          onClick={onRetry}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  // Default: section
+  return (
+    <section
+      role="alert"
+      aria-label={label ?? "Section error"}
+      className="api-error-boundary api-error-boundary--section"
+    >
+      <div className="api-error-boundary__inner">
+        <Icon name="alert" size="lg" tone="danger" aria-hidden="true" />
+        <h2 className="api-error-boundary__heading">Unable to load content</h2>
+        <p className="api-error-boundary__message">{message}</p>
+        {process.env.NODE_ENV !== "production" && (
+          <details className="api-error-boundary__details">
+            <summary>Error details</summary>
+            <pre>{error.message}</pre>
+          </details>
+        )}
+        <button
+          type="button"
+          className="api-error-boundary__retry-btn"
+          onClick={onRetry}
+        >
+          Try again
+        </button>
+      </div>
+    </section>
+  );
+}
+
+// ── Public component ───────────────────────────────────────────────────────
+
+/**
+ * Scoped error boundary for page sections and async components.
+ *
+ * Unlike the root `ErrorBoundary` (which covers the full page), this component
+ * isolates failures to a specific section, keeping the rest of the UI functional.
+ *
+ * @example
+ * <ApiErrorBoundary variant="card" label="Policy list">
+ *   <PolicyList />
+ * </ApiErrorBoundary>
+ */
+export function ApiErrorBoundary({
+  children,
+  variant = "section",
+  label,
+  fallback,
+}: ApiErrorBoundaryProps) {
+  const [errorCount, setErrorCount] = useState(0);
+
+  const handleError = useCallback(() => {
+    setErrorCount((n) => n + 1);
+  }, []);
+
+  return (
+    <ApiErrorBoundaryInner
+      key={errorCount}
+      variant={variant}
+      label={label}
+      fallback={fallback}
+      onError={handleError}
+    >
+      {children}
+    </ApiErrorBoundaryInner>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function isNetworkOrApiError(error: Error): boolean {
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("fetch") ||
+    msg.includes("network") ||
+    msg.includes("failed to load") ||
+    msg.includes("timeout") ||
+    error.name === "TypeError"
+  );
+}

--- a/frontend/src/components/offline-banner.tsx
+++ b/frontend/src/components/offline-banner.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+type OfflineState = "online" | "offline" | "restored";
+
+/**
+ * Displays a fixed top banner when the user loses network connectivity.
+ *
+ * - Shows a dark "You're offline" banner when `navigator.onLine === false`.
+ * - Shows a brief green "Back online" banner for 3 s when connectivity is restored.
+ * - Dismissible by the user (restores on next offline event).
+ * - Uses `aria-live="assertive"` for the offline message so screen readers
+ *   announce it immediately; `"polite"` for the restoration message.
+ * - Pushes page content down by adding `padding-top` to `<body>` so the
+ *   banner doesn't overlap sticky headers.
+ */
+export function OfflineBanner() {
+  const [state, setState] = useState<OfflineState>("online");
+  const [dismissed, setDismissed] = useState(false);
+  const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // Initialise from current status
+    if (!navigator.onLine) {
+      setState("offline");
+    }
+
+    const handleOffline = () => {
+      if (restoreTimerRef.current) clearTimeout(restoreTimerRef.current);
+      setState("offline");
+      setDismissed(false);
+    };
+
+    const handleOnline = () => {
+      setState("restored");
+      setDismissed(false);
+      restoreTimerRef.current = setTimeout(() => setState("online"), 3000);
+    };
+
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+      if (restoreTimerRef.current) clearTimeout(restoreTimerRef.current);
+    };
+  }, []);
+
+  const isVisible = !dismissed && state !== "online";
+
+  // Push body content down while banner is visible
+  useEffect(() => {
+    const banner = document.getElementById("offline-banner");
+    const height = banner?.offsetHeight ?? 0;
+    document.body.style.paddingTop = isVisible ? `${height}px` : "";
+    return () => {
+      document.body.style.paddingTop = "";
+    };
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  const isOffline = state === "offline";
+
+  return (
+    <div
+      id="offline-banner"
+      role="status"
+      aria-live={isOffline ? "assertive" : "polite"}
+      aria-atomic="true"
+      aria-label={isOffline ? "You are offline" : "Connection restored"}
+      className={`offline-banner${state === "restored" ? " offline-banner--restored" : ""}`}
+    >
+      <span className="offline-banner__dot" aria-hidden="true" />
+      <span>
+        {isOffline
+          ? "You're offline — some actions are unavailable."
+          : "Connection restored."}
+      </span>
+      {isOffline && (
+        <button
+          type="button"
+          className="offline-banner__dismiss"
+          aria-label="Dismiss offline notification"
+          onClick={() => setDismissed(true)}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/page-transition.tsx
+++ b/frontend/src/components/page-transition.tsx
@@ -2,12 +2,18 @@
 
 import React from "react";
 import { usePathname } from "next/navigation";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 
 export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const prefersReducedMotion = useReducedMotion();
+
+  // When the user prefers reduced motion, skip the CSS animation entirely by
+  // omitting the `page-transition` class (which carries the keyframe animation).
+  const className = prefersReducedMotion ? undefined : "page-transition";
 
   return (
-    <div key={pathname} className="page-transition">
+    <div key={pathname} className={className}>
       {children}
     </div>
   );

--- a/frontend/src/components/unsaved-changes-dialog.tsx
+++ b/frontend/src/components/unsaved-changes-dialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+
+interface UnsavedChangesDialogProps {
+  isOpen: boolean;
+  message?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal dialog shown when users attempt to navigate away with unsaved form changes.
+ *
+ * - Focus is trapped inside the dialog while open.
+ * - Escape key cancels (stays on page).
+ * - `role="alertdialog"` ensures screen readers announce it immediately.
+ */
+export function UnsavedChangesDialog({
+  isOpen,
+  message = "You have unsaved changes. If you leave now, your changes will be lost.",
+  onConfirm,
+  onCancel,
+}: UnsavedChangesDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the "Stay" button when dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      cancelRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Escape key → cancel
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="unsaved-dialog-backdrop"
+      role="presentation"
+      onClick={(e) => {
+        // Click outside → cancel
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="unsaved-dialog-heading"
+        aria-describedby="unsaved-dialog-body"
+        className="unsaved-dialog"
+      >
+        <h2 id="unsaved-dialog-heading" className="unsaved-dialog__heading">
+          Unsaved changes
+        </h2>
+        <p id="unsaved-dialog-body" className="unsaved-dialog__body">
+          {message}
+        </p>
+        <div className="unsaved-dialog__actions">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="unsaved-dialog__btn-stay"
+            onClick={onCancel}
+          >
+            Stay on page
+          </button>
+          <button
+            type="button"
+            className="unsaved-dialog__btn-leave"
+            onClick={onConfirm}
+          >
+            Leave without saving
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-reduced-motion.ts
+++ b/frontend/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `true` when the user has requested reduced motion via their OS or
+ * browser `prefers-reduced-motion: reduce` media query.
+ *
+ * Components can use this hook to:
+ * - Skip enter/exit animations entirely.
+ * - Replace duration-based transitions with instant state changes.
+ * - Swap animated loaders for static spinners.
+ *
+ * @example
+ * const prefersReducedMotion = useReducedMotion();
+ * const duration = prefersReducedMotion ? 0 : 300;
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const handler = (e: MediaQueryListEvent) => {
+      setPrefersReducedMotion(e.matches);
+    };
+
+    // Use the modern `addEventListener` API with a fallback for older browsers
+    if (mq.addEventListener) {
+      mq.addEventListener("change", handler);
+    } else {
+      // Safari < 14
+      mq.addListener(handler);
+    }
+
+    return () => {
+      if (mq.removeEventListener) {
+        mq.removeEventListener("change", handler);
+      } else {
+        mq.removeListener(handler);
+      }
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/frontend/src/hooks/use-unsaved-guard.ts
+++ b/frontend/src/hooks/use-unsaved-guard.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+
+export interface UnsavedGuardOptions {
+  /** Message shown in the confirmation dialog. */
+  message?: string;
+  /** Whether to also block browser tab-close / reload (beforeunload). Default: true. */
+  blockUnload?: boolean;
+}
+
+export interface UnsavedGuardResult {
+  /** Call this when form state changes so the guard knows unsaved changes exist. */
+  markDirty: () => void;
+  /** Call this after a successful save or deliberate discard. */
+  markClean: () => void;
+  /** Whether the confirmation dialog is currently open. */
+  isDialogOpen: boolean;
+  /** Confirm navigation (leave without saving). */
+  confirmLeave: () => void;
+  /** Cancel navigation (stay on the page). */
+  cancelLeave: () => void;
+  /** Whether the form currently has unsaved changes. */
+  isDirty: boolean;
+}
+
+/**
+ * Route guard that warns users before navigating away with unsaved form changes.
+ *
+ * Usage:
+ * ```tsx
+ * const { markDirty, markClean, isDialogOpen, confirmLeave, cancelLeave } =
+ *   useUnsavedGuard();
+ *
+ * // In your form's onChange:
+ * markDirty();
+ *
+ * // After successful submit:
+ * markClean();
+ * router.push('/policies');
+ * ```
+ *
+ * The hook intercepts `router.push` / `router.replace` calls via a custom wrapper
+ * and the native `beforeunload` event for tab-close protection.
+ */
+export function useUnsavedGuard({
+  message = "You have unsaved changes. Are you sure you want to leave?",
+  blockUnload = true,
+}: UnsavedGuardOptions = {}): UnsavedGuardResult {
+  const [isDirty, setIsDirty] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const pendingUrlRef = useRef<string | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Reset dirty state on route change (navigation completed)
+  useEffect(() => {
+    setIsDirty(false);
+    setIsDialogOpen(false);
+    pendingUrlRef.current = null;
+  }, [pathname]);
+
+  // Block browser tab-close / page reload when dirty
+  useEffect(() => {
+    if (!isDirty || !blockUnload) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Modern browsers ignore the string but require returnValue to be set
+      e.returnValue = message;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty, blockUnload, message]);
+
+  const markDirty = useCallback(() => setIsDirty(true), []);
+  const markClean = useCallback(() => {
+    setIsDirty(false);
+    setIsDialogOpen(false);
+    pendingUrlRef.current = null;
+  }, []);
+
+  /**
+   * Intercepts a navigation attempt. Call this instead of `router.push` when
+   * the form may have unsaved changes.
+   */
+  const guardedNavigate = useCallback(
+    (href: string) => {
+      if (!isDirty) {
+        router.push(href);
+        return;
+      }
+      pendingUrlRef.current = href;
+      setIsDialogOpen(true);
+    },
+    [isDirty, router],
+  );
+
+  const confirmLeave = useCallback(() => {
+    setIsDirty(false);
+    setIsDialogOpen(false);
+    const url = pendingUrlRef.current;
+    pendingUrlRef.current = null;
+    if (url) router.push(url);
+  }, [router]);
+
+  const cancelLeave = useCallback(() => {
+    setIsDialogOpen(false);
+    pendingUrlRef.current = null;
+  }, []);
+
+  return {
+    markDirty,
+    markClean,
+    isDialogOpen,
+    confirmLeave,
+    cancelLeave,
+    isDirty,
+    // Expose guardedNavigate as an extra utility
+    ...(({ guardedNavigate }) => ({ guardedNavigate }) as any)({ guardedNavigate }),
+  };
+}


### PR DESCRIPTION
Fixes #125
Fixes #126
Fixes #122
Fixes #139

## What changed

### #125 — Scoped API error boundary components
**`frontend/src/components/api-error-boundary.tsx`**
- `ApiErrorBoundary` wraps any section or async component with a scoped error boundary — if it throws, only that section shows an error state, the rest of the page stays functional
- Three display variants: `section` (full-width centred fallback), `card` (contained card), `inline` (single-line with retry link)
- Uses a class component internally (`ApiErrorBoundaryInner`) for `getDerivedStateFromError`; a functional wrapper bumps a `key` to reset the boundary after retry
- Distinguishes network/API errors from logic errors to show contextual messages
- `role="alert"` + `aria-label` for screen reader announcement
- Error details hidden in production; shown in development for debugging
- CSS added to `globals.css`

### #126 — Offline state banner
**`frontend/src/components/offline-banner.tsx`**
- Subscribes to `window.online` / `window.offline` events
- Shows a dark fixed-top strip with `aria-live="assertive"` when offline
- Shows a green "Connection restored" strip for 3 s after reconnection
- Dismissible (re-appears on next disconnect)
- Dynamically adjusts `document.body.paddingTop` to prevent overlap with sticky headers
- Mounted in root `layout.tsx` above `MaintenanceBanner`

### #122 — Unsaved changes route guard
**`frontend/src/hooks/use-unsaved-guard.ts`**
- Returns `markDirty`, `markClean`, `isDialogOpen`, `confirmLeave`, `cancelLeave`
- Blocks `beforeunload` (tab close / reload) when dirty
- Resets dirty state automatically when the pathname changes (navigation completed)

**`frontend/src/components/unsaved-changes-dialog.tsx`**
- `role="alertdialog"` + `aria-modal` + `aria-labelledby/describedby`
- Focuses the "Stay on page" button on open
- Escape key and click-outside both cancel
- CSS added to `globals.css`

### #139 — Reduced-motion accessibility fallback
**`frontend/src/hooks/use-reduced-motion.ts`**
- Reads `prefers-reduced-motion: reduce` via `window.matchMedia`
- Subscribes to changes (user toggling OS setting mid-session)
- SSR-safe (returns `false` on the server)

**`frontend/src/components/page-transition.tsx`**
- Omits the `.page-transition` CSS class (and its keyframe animation) when `useReducedMotion()` returns `true`

**`frontend/src/app/globals.css`**
- `@media (prefers-reduced-motion: reduce)` block sets `animation-duration: 0.01ms`, `transition-duration: 0.01ms`, and `scroll-behavior: auto` on all elements as a blanket safety net