### PR TITLE
fix(ci): add Trivy security scanning workflow

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -1,0 +1,83 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy-filesystem:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-fs-results.sarif
+          exit-code: "1"
+
+      - name: Upload filesystem scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs-results.sarif
+          category: trivy-filesystem
+
+  trivy-docker:
+    name: Trivy Docker Image Scan
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+            image: stellarinsure-backend:trivy
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            image: stellarinsure-frontend:trivy
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.name }} Docker image
+        run: |
+          docker build \
+            --file "${{ matrix.dockerfile }}" \
+            --tag "${{ matrix.image }}" \
+            "${{ matrix.context }}"
+
+      - name: Run Trivy Docker image scan for ${{ matrix.name }}
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ matrix.image }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: trivy-image-${{ matrix.name }}-results.sarif
+          exit-code: "1"
+
+      - name: Upload Docker scan results for ${{ matrix.name }}
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-image-${{ matrix.name }}-results.sarif
+          category: trivy-docker-${{ matrix.name }}


### PR DESCRIPTION
## Summary
- add a dedicated Trivy GitHub Actions workflow for push, pull request, manual, and weekly scheduled scans
- scan filesystem for dependency, misconfiguration, and secret issues and scan backend/frontend Docker images
- fail builds on HIGH/CRITICAL findings and upload SARIF results to GitHub Security

## Test plan
- [ ] Trigger workflow on this PR and confirm filesystem and docker scan jobs run
- [ ] Verify SARIF results appear in GitHub Security > Code scanning alerts
- [ ] Confirm weekly schedule is present for automatic recurring scans

Closes ChaoLing140/StellarInsure#218
