### PR TITLE
feat(frontend): add keyboard shortcuts help modal

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1610,6 +1610,87 @@ dt,
   font-size: var(--step-0);
 }
 
+.ks-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  background: rgba(16, 37, 66, 0.35);
+}
+
+.ks-panel {
+  width: min(46rem, 94vw);
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--card-border);
+  background: var(--surface);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.ks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.ks-header h3 {
+  margin: 0;
+}
+
+.ks-groups {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.ks-group {
+  border: 1px solid var(--card-border);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.ks-group h4 {
+  margin: 0 0 0.55rem;
+  font-size: var(--step-0);
+}
+
+.ks-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.ks-group li {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 10.5rem) 1fr;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.ks-group kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--card-border);
+  font-size: var(--step--1);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: rgba(16, 37, 66, 0.08);
+}
+
+.ks-group span {
+  color: var(--text-muted);
+  font-size: var(--step-0);
+}
+
 .chart-bars {
   display: grid;
   gap: 0.6rem;

--- a/frontend/src/components/keyboard-shortcuts-help.tsx
+++ b/frontend/src/components/keyboard-shortcuts-help.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ShortcutGroup = {
+  title: string;
+  items: Array<{
+    keys: string;
+    action: string;
+  }>;
+};
+
+function isTypingTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName.toLowerCase();
+  return tagName === "input" || tagName === "textarea" || target.isContentEditable;
+}
+
+export function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+
+      if (isTypingTarget(event.target) || event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+
+      if (event.key === "?") {
+        event.preventDefault();
+        setOpen(true);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const shortcuts = useMemo<ShortcutGroup[]>(
+    () => [
+      {
+        title: "Navigation",
+        items: [
+          { keys: "Ctrl/Cmd + K", action: "Open or close quick navigation palette" },
+          { keys: "Enter", action: "Run selected quick action in palette" },
+        ],
+      },
+      {
+        title: "Accessibility",
+        items: [
+          { keys: "?", action: "Open keyboard shortcuts help (outside text fields)" },
+          { keys: "Esc", action: "Close open modal, drawer, or command palette" },
+          { keys: "Tab / Shift + Tab", action: "Move focus forward or backward" },
+        ],
+      },
+    ],
+    [],
+  );
+
+  return (
+    <>
+      <button
+        className="cta-secondary"
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open keyboard shortcuts help"
+      >
+        Keyboard Help
+      </button>
+      {open ? (
+        <div className="ks-backdrop" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts help">
+          <div className="ks-panel">
+            <header className="ks-header">
+              <h3>Keyboard shortcuts</h3>
+              <button
+                type="button"
+                className="topbar-action-btn"
+                onClick={() => setOpen(false)}
+                aria-label="Close keyboard shortcuts help"
+              >
+                Close
+              </button>
+            </header>
+            <div className="ks-groups">
+              {shortcuts.map((group) => (
+                <section className="ks-group" key={group.title} aria-label={`${group.title} shortcuts`}>
+                  <h4>{group.title}</h4>
+                  <ul>
+                    {group.items.map((item) => (
+                      <li key={`${group.title}-${item.keys}`}>
+                        <kbd>{item.keys}</kbd>
+                        <span>{item.action}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/site-header.tsx
+++ b/frontend/src/components/site-header.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcher } from "@/components/language-switcher";
 import { NetworkSwitcher } from "@/components/network-switcher";
 import { WalletConnectionButton } from "@/components/wallet-connection-button";
 import { CommandPalette } from "@/components/command-palette";
+import { KeyboardShortcutsHelp } from "@/components/keyboard-shortcuts-help";
 import { NotificationsPanel } from "@/components/notifications-panel";
 import { Icon } from "@/components/icon";
 
@@ -121,6 +122,7 @@ export function SiteHeader() {
             <Icon name="bell" size="md" tone="muted" />
           </button>
           <CommandPalette />
+          <KeyboardShortcutsHelp />
           <NetworkSwitcher />
           <WalletConnectionButton />
           <LanguageSwitcher />
@@ -147,6 +149,7 @@ export function SiteHeader() {
         </nav>
         <div className="mobile-drawer__actions">
           <CommandPalette />
+          <KeyboardShortcutsHelp />
           <NetworkSwitcher />
           <WalletConnectionButton />
           <LanguageSwitcher />


### PR DESCRIPTION
## Summary
- add a new keyboard shortcuts help modal component available from header actions on desktop and mobile
- support opening help with `?` (outside text inputs) and closing with `Esc`
- document available navigation and accessibility keyboard actions in a readable grouped layout

## Test plan
- [x] Run `npm run lint` in `frontend`
- [ ] Open header actions and verify `Keyboard Help` opens the modal
- [ ] Press `?` outside text fields and verify the modal opens
- [ ] Press `Esc` and verify the modal closes
- [ ] In an input/textarea, press `?` and verify the modal does not open
- [ ] Verify modal usability on both desktop header and mobile drawer

Closes ChaoLing140/StellarInsure#111
