### PR TITLE
feat(frontend): add reusable SEO helper and route metadata

### DIFF
--- a/frontend/src/app/claims/[claimId]/page.metadata.test.tsx
+++ b/frontend/src/app/claims/[claimId]/page.metadata.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { absoluteUrl } from "@/lib/seo";
+
+import { generateMetadata } from "./page";
+
+describe("ClaimDetailPage metadata", () => {
+  it("generates route-specific metadata for known claims", () => {
+    const metadata = generateMetadata({ params: { claimId: "CLM-0091" } });
+
+    expect(metadata.title).toBe("Claim CLM-0091");
+    expect(metadata.description).toMatch(/payout timeline/i);
+    expect(metadata.alternates?.canonical).toBe(absoluteUrl("/claims/CLM-0091"));
+    expect(metadata.openGraph?.url).toBe(absoluteUrl("/claims/CLM-0091"));
+    expect(metadata.openGraph?.images?.[0]?.url).toBe("/opengraph-image");
+  });
+
+  it("falls back to generic metadata for unknown claims", () => {
+    const metadata = generateMetadata({ params: { claimId: "CLM-7777" } });
+
+    expect(metadata.title).toBe("Claim CLM-7777");
+    expect(metadata.description).toMatch(/review claim evidence/i);
+    expect(metadata.alternates?.canonical).toBe(absoluteUrl("/claims/CLM-7777"));
+  });
+});

--- a/frontend/src/app/claims/[claimId]/page.tsx
+++ b/frontend/src/app/claims/[claimId]/page.tsx
@@ -1,10 +1,56 @@
-import React from "react";
+import type { Metadata } from "next";
+
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
+
 import ClaimDetailPageClient from "./claim-detail-page-client";
+
+const CLAIM_DETAILS: Record<string, { title: string; description: string }> = {
+  "CLM-0091": {
+    title: "Claim CLM-0091",
+    description: "Review weather-trigger evidence, payout timeline, and transaction details for claim CLM-0091.",
+  },
+  "CLM-0042": {
+    title: "Claim CLM-0042",
+    description: "Track review progress, oracle evidence, and pending status for claim CLM-0042.",
+  },
+};
+
+function getPageCopy(claimId: string) {
+  return (
+    CLAIM_DETAILS[claimId] ?? {
+      title: `Claim ${claimId}`,
+      description: "Review claim evidence, lifecycle events, and payout status for your StellarInsure submission.",
+    }
+  );
+}
+
+export function generateMetadata({ params }: { params: { claimId: string } }): Metadata {
+  const copy = getPageCopy(params.claimId);
+
+  return buildMetadata({
+    title: copy.title,
+    description: copy.description,
+    pathname: `/claims/${params.claimId}`,
+    keywords: ["claim detail", "claim evidence", "payout status", "review timeline"],
+  });
+}
 
 export default function ClaimDetailPage({
   params,
 }: {
   params: { claimId: string };
 }) {
-  return <ClaimDetailPageClient params={params} />;
+  const copy = getPageCopy(params.claimId);
+
+  return (
+    <>
+      <PageSeo
+        title={copy.title}
+        description={copy.description}
+        pathname={`/claims/${params.claimId}`}
+      />
+      <ClaimDetailPageClient params={params} />
+    </>
+  );
 }

--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -1,8 +1,7 @@
-import React from "react";
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import CreatePolicyPageClient from "./create-page-client";
 
@@ -19,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function CreatePolicyPage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/create",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/create" />
       <CreatePolicyPageClient />
     </>
   );

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import TransactionHistoryPageClient from "./history-page-client";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function TransactionHistoryPage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/history",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/history" />
       <TransactionHistoryPageClient />
     </>
   );

--- a/frontend/src/app/legal/privacy/page.tsx
+++ b/frontend/src/app/legal/privacy/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import PrivacyPageClient from "./privacy-page-client";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function PrivacyPage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/legal/privacy",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/legal/privacy" />
       <PrivacyPageClient />
     </>
   );

--- a/frontend/src/app/legal/terms/page.tsx
+++ b/frontend/src/app/legal/terms/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import TermsPageClient from "./terms-page-client";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function TermsPage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/legal/terms",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/legal/terms" />
       <TermsPageClient />
     </>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import HomePageClient from "./home-page-client";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function HomePage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/" />
       <HomePageClient />
     </>
   );

--- a/frontend/src/app/policies/[policyId]/page.tsx
+++ b/frontend/src/app/policies/[policyId]/page.tsx
@@ -1,8 +1,7 @@
-import React from "react";
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import PolicyDetailPageClient from "./policy-detail-page-client";
 
@@ -42,12 +41,10 @@ export default function PolicyDetailPage({ params }: { params: { policyId: strin
 
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${copy.title} | StellarInsure`,
-          description: copy.description,
-          pathname: `/policies/${params.policyId}`,
-        })}
+      <PageSeo
+        title={copy.title}
+        description={copy.description}
+        pathname={`/policies/${params.policyId}`}
       />
       <PolicyDetailPageClient params={params} />
     </>

--- a/frontend/src/app/policies/page.tsx
+++ b/frontend/src/app/policies/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import { StructuredData } from "@/components/structured-data";
-import { buildMetadata, webPageStructuredData } from "@/lib/seo";
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
 
 import PoliciesListPageClient from "./policies-list-page-client";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = buildMetadata({
 export default function PoliciesListPage() {
   return (
     <>
-      <StructuredData
-        data={webPageStructuredData({
-          title: `${PAGE_TITLE} | StellarInsure`,
-          description: PAGE_DESCRIPTION,
-          pathname: "/policies",
-        })}
-      />
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/policies" />
       <PoliciesListPageClient />
     </>
   );

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,12 +1,25 @@
 import type { Metadata } from "next";
 
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
+
 import SettingsPageClient from "./settings-page-client";
 
-export const metadata: Metadata = {
-  title: "Account Preferences",
-  description: "Manage timezone, currency display, and communication preferences.",
-};
+const PAGE_TITLE = "Account Preferences";
+const PAGE_DESCRIPTION = "Manage timezone, currency display, and communication preferences.";
+
+export const metadata: Metadata = buildMetadata({
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  pathname: "/settings",
+  keywords: ["settings", "account preferences", "timezone", "currency"],
+});
 
 export default function SettingsPage() {
-  return <SettingsPageClient />;
+  return (
+    <>
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/settings" />
+      <SettingsPageClient />
+    </>
+  );
 }

--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -1,11 +1,25 @@
-import React from "react";
+import type { Metadata } from "next";
+
+import { PageSeo } from "@/components/page-seo";
+import { buildMetadata } from "@/lib/seo";
+
 import TreasuryPageClient from "./treasury-page-client";
 
-export const metadata = {
-    title: "Treasury | StellarInsure",
-    description: "Manage your risk pool deposits and withdrawals.",
-};
+const PAGE_TITLE = "Treasury";
+const PAGE_DESCRIPTION = "Manage your risk pool deposits and withdrawals.";
+
+export const metadata: Metadata = buildMetadata({
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  pathname: "/treasury",
+  keywords: ["treasury", "risk pool", "deposits", "withdrawals"],
+});
 
 export default function TreasuryPage() {
-    return <TreasuryPageClient />;
+  return (
+    <>
+      <PageSeo title={PAGE_TITLE} description={PAGE_DESCRIPTION} pathname="/treasury" />
+      <TreasuryPageClient />
+    </>
+  );
 }

--- a/frontend/src/components/page-seo.tsx
+++ b/frontend/src/components/page-seo.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { SITE_NAME, webPageStructuredData } from "@/lib/seo";
+
+import { StructuredData } from "./structured-data";
+
+interface PageSeoProps {
+  title: string;
+  description: string;
+  pathname: string;
+}
+
+export function PageSeo({ title, description, pathname }: PageSeoProps) {
+  return (
+    <StructuredData
+      data={webPageStructuredData({
+        title: `${title} | ${SITE_NAME}`,
+        description,
+        pathname,
+      })}
+    />
+  );
+}


### PR DESCRIPTION
Closes #153
Closes #152
Closes #147
Closes #141

## Changes
- add a reusable PageSeo component to centralize structured SEO page data
- switch route pages to use the shared SEO component
- add claim detail route-specific metadata generation and structured SEO data
- normalize settings and treasury metadata to use shared metadata builder with OG defaults
- add metadata tests for claim detail route generation

## Testing
- Not run (skipped per request).