### PR TITLE
Resolves four frontend issues for StellarInsure

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useEffect } from "react";
+import Link from "next/link";
+import { logError } from "@/lib/error-logger";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    logError(error, { tags: { source: "next-error-boundary" } });
+  }, [error]);
+
+  return (
+    <main id="main-content" tabIndex={-1} className="error-page" aria-labelledby="error-heading">
+      <div className="error-page__card motion-panel">
+        <span className="eyebrow" aria-hidden="true">500</span>
+
+        <h1 id="error-heading" className="error-page__heading">
+          Something went wrong
+        </h1>
+
+        <p className="error-page__message">
+          We encountered an unexpected error. Our team has been notified.
+          You can try again or return to the home page.
+        </p>
+
+        {process.env.NODE_ENV !== "production" && error.message && (
+          <details className="error-page__details">
+            <summary>Error details</summary>
+            <pre className="error-page__pre">{error.message}</pre>
+            {error.digest && (
+              <p className="error-page__digest">Digest: {error.digest}</p>
+            )}
+          </details>
+        )}
+
+        <nav className="error-page__actions cta-row" aria-label="Recovery options">
+          <button type="button" className="cta-primary" onClick={reset}>
+            Try again
+          </button>
+          <Link href="/" className="cta-secondary">
+            Go to home
+          </Link>
+        </nav>
+
+        <p className="error-page__support">
+          Still having issues?{" "}
+          <a
+            href="mailto:support@stellarinsure.io"
+            className="error-page__support-link"
+          >
+            Contact support
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4491,6 +4491,95 @@ dt,
   }
 }
 
+/* ── Custom error pages (404 / 500) ─────────────────────────────────── */
+.error-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: var(--space-5) var(--space-4);
+}
+
+.error-page__card {
+  width: 100%;
+  max-width: 520px;
+  background: var(--surface);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6) var(--space-5);
+  box-shadow: var(--shadow-100);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.error-page__heading {
+  font-size: var(--step-4);
+  font-weight: 700;
+  color: var(--text);
+  margin: 0;
+}
+
+.error-page__message {
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 38ch;
+}
+
+.error-page__actions {
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.error-page__details {
+  width: 100%;
+  text-align: left;
+  background: var(--background);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  cursor: pointer;
+}
+
+.error-page__details summary {
+  font-weight: 600;
+  color: var(--text);
+  font-size: var(--step-0);
+}
+
+.error-page__pre {
+  margin-top: var(--space-2);
+  font-size: var(--step--1);
+  font-family: var(--font-family-mono);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+}
+
+.error-page__digest {
+  margin-top: var(--space-1);
+  font-size: var(--step--1);
+  color: var(--text-muted);
+}
+
+.error-page__support {
+  font-size: var(--step-0);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.error-page__support-link {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.error-page__support-link:hover,
+.error-page__support-link:focus-visible {
+  color: var(--accent-strong);
+}
+
 /* ── Reduced-motion (#139) ───────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { OnboardingFlow } from "@/components/onboarding";
 import { OnboardingTooltips } from "@/components/onboarding-tooltips";
 import { PageTransition } from "@/components/page-transition";
 import { LanguageProvider } from "@/i18n/provider";
+import { AuthProvider } from "@/context/auth-context";
 import {
   SITE_URL,
   absoluteUrl,
@@ -76,6 +77,7 @@ export default function RootLayout({
       <body>
         <ErrorBoundary>
           <LanguageProvider>
+            <AuthProvider>
             <WalletProvider>
               <script defer data-domain="stellarinsure.io" src="https://plausible.io/js/script.js"></script>
               <StructuredData data={organizationStructuredData()} />
@@ -101,6 +103,7 @@ export default function RootLayout({
                 </footer>
               </div>
             </WalletProvider>
+            </AuthProvider>
           </LanguageProvider>
         </ErrorBoundary>
       </body>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  description: "The page you are looking for does not exist.",
+};
+
+export default function NotFound() {
+  return (
+    <main id="main-content" tabIndex={-1} className="error-page" aria-labelledby="error-heading">
+      <div className="error-page__card motion-panel">
+        <span className="eyebrow" aria-hidden="true">404</span>
+
+        <h1 id="error-heading" className="error-page__heading">
+          Page not found
+        </h1>
+
+        <p className="error-page__message">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          Check the URL or navigate back to a known page.
+        </p>
+
+        <nav className="error-page__actions cta-row" aria-label="Recovery options">
+          <Link href="/" className="cta-primary">
+            Go to home
+          </Link>
+          <Link href="/policies" className="cta-secondary">
+            View policies
+          </Link>
+        </nav>
+
+        <p className="error-page__support">
+          Need help?{" "}
+          <a
+            href="mailto:support@stellarinsure.io"
+            className="error-page__support-link"
+          >
+            Contact support
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/error-boundary.test.tsx
+++ b/frontend/src/components/error-boundary.test.tsx
@@ -3,9 +3,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ErrorBoundary } from "./error-boundary";
 
-// Mock Sentry
-vi.mock("@sentry/nextjs", () => ({
-  captureException: vi.fn(),
+vi.mock("@/lib/error-logger", () => ({
+  logError: vi.fn(),
 }));
 
 // Component that throws an error for testing
@@ -95,8 +94,8 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Working Component")).toBeInTheDocument();
   });
 
-  it("logs errors to Sentry if available", () => {
-    const sentryMock = require("@sentry/nextjs");
+  it("delegates error to the logger adapter", async () => {
+    const { logError } = await import("@/lib/error-logger");
 
     render(
       <ErrorBoundary>
@@ -104,13 +103,9 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
-    expect(sentryMock.captureException).toHaveBeenCalledWith(
+    expect(logError).toHaveBeenCalledWith(
       expect.any(Error),
-      expect.objectContaining({
-        contexts: expect.objectContaining({
-          react: expect.any(Object),
-        }),
-      })
+      expect.objectContaining({ componentStack: expect.anything() }),
     );
   });
 });

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { ErrorInfo, ReactNode } from "react";
+import { logError } from "@/lib/error-logger";
 
 interface Props {
   children: ReactNode;
@@ -9,15 +10,6 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
-}
-
-let sentryClient: any = null;
-
-// Attempt to import Sentry if available
-try {
-  sentryClient = require("@sentry/nextjs");
-} catch {
-  // Sentry not installed, will gracefully handle this
 }
 
 export class ErrorBoundary extends React.Component<Props, State> {
@@ -31,19 +23,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // Log to Sentry if available
-    if (sentryClient?.captureException) {
-      sentryClient.captureException(error, {
-        contexts: {
-          react: {
-            componentStack: errorInfo.componentStack,
-          },
-        },
-      });
-    } else {
-      // Fallback logging to console
-      console.error("Error caught by Error Boundary:", error, errorInfo);
-    }
+    logError(error, { componentStack: errorInfo.componentStack });
   }
 
   handleRetry = () => {

--- a/frontend/src/context/auth-context.test.tsx
+++ b/frontend/src/context/auth-context.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { AuthProvider, useAuth } from "./auth-context";
+
+function StatusDisplay() {
+  const { status, session, isAuthenticated } = useAuth();
+  return (
+    <div>
+      <span data-testid="status">{status}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="userId">{session?.userId ?? "none"}</span>
+    </div>
+  );
+}
+
+function SignInButton() {
+  const { signIn } = useAuth();
+  return (
+    <button
+      onClick={() =>
+        signIn({ userId: "u1", walletAddress: "GABC123", displayName: "Alice" })
+      }
+    >
+      Sign In
+    </button>
+  );
+}
+
+function SignOutButton() {
+  const { signOut } = useAuth();
+  return <button onClick={signOut}>Sign Out</button>;
+}
+
+function TestApp() {
+  return (
+    <AuthProvider>
+      <StatusDisplay />
+      <SignInButton />
+      <SignOutButton />
+    </AuthProvider>
+  );
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("starts in loading then resolves to unauthenticated with no session", async () => {
+    render(<TestApp />);
+    await act(async () => {});
+    expect(screen.getByTestId("status").textContent).toBe("unauthenticated");
+    expect(screen.getByTestId("authenticated").textContent).toBe("false");
+  });
+
+  it("restores session from sessionStorage on mount", async () => {
+    sessionStorage.setItem(
+      "stellarinsure-session",
+      JSON.stringify({ userId: "u99", walletAddress: null, displayName: "Bob" }),
+    );
+    render(<TestApp />);
+    await act(async () => {});
+    expect(screen.getByTestId("status").textContent).toBe("authenticated");
+    expect(screen.getByTestId("userId").textContent).toBe("u99");
+  });
+
+  it("signIn sets status to authenticated and persists to sessionStorage", async () => {
+    render(<TestApp />);
+    await act(async () => {});
+    await act(async () => {
+      screen.getByRole("button", { name: "Sign In" }).click();
+    });
+    expect(screen.getByTestId("status").textContent).toBe("authenticated");
+    expect(screen.getByTestId("userId").textContent).toBe("u1");
+    expect(sessionStorage.getItem("stellarinsure-session")).toContain("u1");
+  });
+
+  it("signOut clears session and sessionStorage", async () => {
+    render(<TestApp />);
+    await act(async () => {});
+    await act(async () => {
+      screen.getByRole("button", { name: "Sign In" }).click();
+    });
+    await act(async () => {
+      screen.getByRole("button", { name: "Sign Out" }).click();
+    });
+    expect(screen.getByTestId("status").textContent).toBe("unauthenticated");
+    expect(screen.getByTestId("userId").textContent).toBe("none");
+    expect(sessionStorage.getItem("stellarinsure-session")).toBeNull();
+  });
+
+  it("useAuth throws when used outside AuthProvider", () => {
+    const ThrowingComponent = () => {
+      useAuth();
+      return null;
+    };
+    expect(() => render(<ThrowingComponent />)).toThrow(
+      "useAuth must be used inside AuthProvider",
+    );
+  });
+});

--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+const SESSION_KEY = "stellarinsure-session";
+
+export type SessionStatus = "loading" | "authenticated" | "unauthenticated";
+
+export interface UserSession {
+  userId: string;
+  walletAddress: string | null;
+  displayName: string | null;
+}
+
+export interface AuthContextValue {
+  status: SessionStatus;
+  session: UserSession | null;
+  isAuthenticated: boolean;
+  signIn(session: UserSession): void;
+  signOut(): void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<SessionStatus>("loading");
+  const [session, setSession] = useState<UserSession | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setStatus("unauthenticated");
+      return;
+    }
+    try {
+      const raw = window.sessionStorage.getItem(SESSION_KEY);
+      if (raw) {
+        setSession(JSON.parse(raw) as UserSession);
+        setStatus("authenticated");
+      } else {
+        setStatus("unauthenticated");
+      }
+    } catch {
+      setStatus("unauthenticated");
+    }
+  }, []);
+
+  function signIn(newSession: UserSession) {
+    setSession(newSession);
+    setStatus("authenticated");
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(newSession));
+    }
+  }
+
+  function signOut() {
+    setSession(null);
+    setStatus("unauthenticated");
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(SESSION_KEY);
+    }
+  }
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      status,
+      session,
+      isAuthenticated: status === "authenticated",
+      signIn,
+      signOut,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [status, session],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error("useAuth must be used inside AuthProvider");
+  return context;
+}

--- a/frontend/src/lib/error-logger.test.ts
+++ b/frontend/src/lib/error-logger.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+describe("error-logger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  it("logError does not throw when called without context", async () => {
+    const { logError } = await import("./error-logger");
+    expect(() => logError(new Error("simple"))).not.toThrow();
+  });
+
+  it("logError passes componentStack as react context to Sentry", async () => {
+    const sentry = await import("@sentry/nextjs");
+    const { logError } = await import("./error-logger");
+    const err = new Error("ctx-error");
+    logError(err, { componentStack: "at Foo" });
+    expect(sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        contexts: expect.objectContaining({
+          react: expect.objectContaining({ componentStack: "at Foo" }),
+        }),
+      }),
+    );
+  });
+
+  it("logError passes tags and extra when provided", async () => {
+    const sentry = await import("@sentry/nextjs");
+    const { logError } = await import("./error-logger");
+    const err = new Error("tagged");
+    logError(err, { tags: { page: "home" }, extra: { userId: "u1" } });
+    expect(sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        tags: { page: "home" },
+        extra: { userId: "u1" },
+      }),
+    );
+  });
+
+  it("logError omits contexts key when componentStack is null", async () => {
+    const sentry = await import("@sentry/nextjs");
+    const { logError } = await import("./error-logger");
+    const err = new Error("no-stack");
+    logError(err, { tags: { page: "home" } });
+    const call = (sentry.captureException as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]).not.toHaveProperty("contexts");
+  });
+
+  it("logMessage calls captureMessage with the given level", async () => {
+    const sentry = await import("@sentry/nextjs");
+    const { logMessage } = await import("./error-logger");
+    logMessage("hello", "warn");
+    expect(sentry.captureMessage).toHaveBeenCalledWith("hello", "warn");
+  });
+
+  it("logMessage defaults to info level", async () => {
+    const sentry = await import("@sentry/nextjs");
+    const { logMessage } = await import("./error-logger");
+    logMessage("greet");
+    expect(sentry.captureMessage).toHaveBeenCalledWith("greet", "info");
+  });
+});

--- a/frontend/src/lib/error-logger.ts
+++ b/frontend/src/lib/error-logger.ts
@@ -1,0 +1,55 @@
+export interface ErrorLogContext {
+  componentStack?: string | null;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}
+
+type LogLevel = "info" | "warn" | "error";
+
+interface ErrorLogger {
+  logError(error: Error, context?: ErrorLogContext): void;
+  logMessage(message: string, level?: LogLevel): void;
+}
+
+function buildSentryAdapter(): ErrorLogger | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const sentry = require("@sentry/nextjs");
+    if (typeof sentry?.captureException !== "function") return null;
+    return {
+      logError(error, context) {
+        sentry.captureException(error, {
+          ...(context?.componentStack && {
+            contexts: { react: { componentStack: context.componentStack } },
+          }),
+          ...(context?.tags && { tags: context.tags }),
+          ...(context?.extra && { extra: context.extra }),
+        });
+      },
+      logMessage(message, level = "info") {
+        sentry.captureMessage(message, level);
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+const consoleAdapter: ErrorLogger = {
+  logError(error, context) {
+    console.error("[ErrorLogger]", error, context ?? "");
+  },
+  logMessage(message, level = "info") {
+    (console[level] as typeof console.log)("[ErrorLogger]", message);
+  },
+};
+
+const _adapter: ErrorLogger = buildSentryAdapter() ?? consoleAdapter;
+
+export function logError(error: Error, context?: ErrorLogContext): void {
+  _adapter.logError(error, context);
+}
+
+export function logMessage(message: string, level?: LogLevel): void {
+  _adapter.logMessage(message, level);
+}

--- a/frontend/src/lib/fixtures/claims.ts
+++ b/frontend/src/lib/fixtures/claims.ts
@@ -1,0 +1,161 @@
+export type ClaimStatus = "Pending" | "Approved" | "Rejected";
+
+export interface ClaimEvidenceItem {
+  id: string;
+  label: string;
+  source: string;
+  verifiedAt?: string;
+}
+
+export interface ClaimReviewEvent {
+  id: string;
+  actor: string;
+  action: string;
+  note: string;
+  timestamp: string;
+}
+
+export interface ClaimLifecycleEvent {
+  key: string;
+  label: string;
+  timestamp: string;
+  status: "done" | "active" | "pending";
+}
+
+export interface ClaimFixture {
+  id: string;
+  policyId: string;
+  policyTitle: string;
+  policyType: string;
+  status: ClaimStatus;
+  submittedAt: string;
+  requestedAmount: number;
+  payoutAmount?: number;
+  payoutTxHash?: string;
+  triggerCondition: string;
+  evidence: ClaimEvidenceItem[];
+  reviewEvents: ClaimReviewEvent[];
+  lifecycleEvents: ClaimLifecycleEvent[];
+}
+
+export const MOCK_CLAIMS: ClaimFixture[] = [
+  {
+    id: "CLM-0091",
+    policyId: "weather-alpha",
+    policyTitle: "Northern Plains Weather Guard",
+    policyType: "weather",
+    status: "Approved",
+    submittedAt: "2026-03-10T09:00:00Z",
+    requestedAmount: 4500,
+    payoutAmount: 4500,
+    payoutTxHash: "a1b2c3d4e5f6789012345678901234567890abcd",
+    triggerCondition: "Rainfall below 10mm over 30-day window",
+    evidence: [
+      {
+        id: "ev-1",
+        label: "Rainfall Station Export",
+        source: "NOAA Weather API",
+        verifiedAt: "2026-03-11T14:00:00Z",
+      },
+      {
+        id: "ev-2",
+        label: "Satellite Imagery Report",
+        source: "NASA Earth Observation",
+        verifiedAt: "2026-03-12T10:30:00Z",
+      },
+    ],
+    reviewEvents: [
+      {
+        id: "rev-1",
+        actor: "Oracle Node #3",
+        action: "Evidence Verified",
+        note: "Rainfall data confirmed below threshold.",
+        timestamp: "2026-03-11T14:00:00Z",
+      },
+      {
+        id: "rev-2",
+        actor: "Smart Contract",
+        action: "Claim Approved",
+        note: "Payout of 4,500 XLM triggered automatically.",
+        timestamp: "2026-03-12T08:00:00Z",
+      },
+    ],
+    lifecycleEvents: [
+      { key: "submitted", label: "Claim Submitted", timestamp: "2026-03-10T09:00:00Z", status: "done" },
+      { key: "evidence", label: "Evidence Verified", timestamp: "2026-03-11T14:00:00Z", status: "done" },
+      { key: "approved", label: "Claim Approved", timestamp: "2026-03-12T08:00:00Z", status: "done" },
+      { key: "payout", label: "Payout Issued", timestamp: "2026-03-12T09:15:00Z", status: "done" },
+    ],
+  },
+  {
+    id: "CLM-0042",
+    policyId: "flight-orbit",
+    policyTitle: "Flight Orbit Delay Cover",
+    policyType: "flight",
+    status: "Pending",
+    submittedAt: "2026-04-01T12:00:00Z",
+    requestedAmount: 1800,
+    triggerCondition: "Flight delay exceeding 3 hours",
+    evidence: [
+      {
+        id: "ev-3",
+        label: "Airline Delay Report",
+        source: "Airline Delay API",
+      },
+    ],
+    reviewEvents: [
+      {
+        id: "rev-3",
+        actor: "Oracle Node #1",
+        action: "Evidence Submitted",
+        note: "Awaiting oracle confirmation.",
+        timestamp: "2026-04-01T13:00:00Z",
+      },
+    ],
+    lifecycleEvents: [
+      { key: "submitted", label: "Claim Submitted", timestamp: "2026-04-01T12:00:00Z", status: "done" },
+      { key: "evidence", label: "Evidence Verified", timestamp: "", status: "active" },
+      { key: "approved", label: "Claim Approved", timestamp: "", status: "pending" },
+      { key: "payout", label: "Payout Issued", timestamp: "", status: "pending" },
+    ],
+  },
+  {
+    id: "CLM-0017",
+    policyId: "smart-contract-alpha",
+    policyTitle: "Smart Contract Risk Shield",
+    policyType: "smart-contract",
+    status: "Rejected",
+    submittedAt: "2026-02-20T08:30:00Z",
+    requestedAmount: 8000,
+    triggerCondition: "Smart contract exploit detected with > $50k loss",
+    evidence: [
+      {
+        id: "ev-4",
+        label: "Audit Report",
+        source: "Ethereum Audit API",
+        verifiedAt: "2026-02-21T11:00:00Z",
+      },
+    ],
+    reviewEvents: [
+      {
+        id: "rev-4",
+        actor: "Oracle Node #2",
+        action: "Evidence Verified",
+        note: "Loss threshold not met according to on-chain data.",
+        timestamp: "2026-02-21T11:00:00Z",
+      },
+      {
+        id: "rev-5",
+        actor: "Smart Contract",
+        action: "Claim Rejected",
+        note: "Trigger condition not satisfied.",
+        timestamp: "2026-02-22T09:00:00Z",
+      },
+    ],
+    lifecycleEvents: [
+      { key: "submitted", label: "Claim Submitted", timestamp: "2026-02-20T08:30:00Z", status: "done" },
+      { key: "evidence", label: "Evidence Verified", timestamp: "2026-02-21T11:00:00Z", status: "done" },
+      { key: "rejected", label: "Claim Rejected", timestamp: "2026-02-22T09:00:00Z", status: "done" },
+    ],
+  },
+];

--- a/frontend/src/lib/fixtures/index.ts
+++ b/frontend/src/lib/fixtures/index.ts
@@ -1,0 +1,3 @@
+export * from "./claims";
+export * from "./policies";
+export * from "./transactions";

--- a/frontend/src/lib/fixtures/policies.ts
+++ b/frontend/src/lib/fixtures/policies.ts
@@ -1,0 +1,83 @@
+export type PolicyStatus = "active" | "pending" | "expired" | "claimed";
+export type PolicyType = "weather" | "flight" | "smart-contract" | "asset" | "health";
+
+export interface PolicyFixture {
+  id: string;
+  title: string;
+  type: PolicyType;
+  status: PolicyStatus;
+  coverageAmount: number;
+  premiumAmount: number;
+  createdAt: string;
+  expiresAt: string;
+  oracleSource: string;
+}
+
+export const MOCK_POLICIES: PolicyFixture[] = [
+  {
+    id: "weather-alpha",
+    title: "Northern Plains Weather Guard",
+    type: "weather",
+    status: "active",
+    coverageAmount: 5000,
+    premiumAmount: 125.5,
+    createdAt: "2026-02-15",
+    expiresAt: "2026-05-15",
+    oracleSource: "NOAA Weather API",
+  },
+  {
+    id: "flight-orbit",
+    title: "Flight Orbit Delay Cover",
+    type: "flight",
+    status: "active",
+    coverageAmount: 2000,
+    premiumAmount: 45.0,
+    createdAt: "2026-03-01",
+    expiresAt: "2026-06-01",
+    oracleSource: "Airline Delay API",
+  },
+  {
+    id: "smart-contract-alpha",
+    title: "Smart Contract Risk Shield",
+    type: "smart-contract",
+    status: "active",
+    coverageAmount: 10000,
+    premiumAmount: 250.0,
+    createdAt: "2026-01-10",
+    expiresAt: "2026-07-10",
+    oracleSource: "Ethereum Audit API",
+  },
+  {
+    id: "health-basic",
+    title: "Basic Health Coverage",
+    type: "health",
+    status: "pending",
+    coverageAmount: 3000,
+    premiumAmount: 75.0,
+    createdAt: "2026-04-01",
+    expiresAt: "2026-10-01",
+    oracleSource: "Health Oracle",
+  },
+  {
+    id: "asset-protection",
+    title: "Asset Value Protection",
+    type: "asset",
+    status: "expired",
+    coverageAmount: 8000,
+    premiumAmount: 200.0,
+    createdAt: "2025-10-01",
+    expiresAt: "2026-01-01",
+    oracleSource: "Price Feed API",
+  },
+  {
+    id: "weather-coastal",
+    title: "Coastal Storm Parametric Cover",
+    type: "weather",
+    status: "claimed",
+    coverageAmount: 12000,
+    premiumAmount: 310.0,
+    createdAt: "2025-11-15",
+    expiresAt: "2026-02-15",
+    oracleSource: "NOAA Weather API",
+  },
+];

--- a/frontend/src/lib/fixtures/transactions.ts
+++ b/frontend/src/lib/fixtures/transactions.ts
@@ -1,0 +1,42 @@
+export type TransactionType = "premium" | "payout" | "refund";
+export type TransactionStatus = "successful" | "pending" | "failed";
+
+export interface TransactionFixture {
+  id: number;
+  transaction_hash: string;
+  amount: number;
+  transaction_type: TransactionType;
+  status: TransactionStatus;
+  policy_id: number | null;
+  claim_id: number | null;
+  created_at: string;
+}
+
+const TYPES: TransactionType[] = ["premium", "payout", "refund", "premium", "premium", "payout"];
+const STATUSES: TransactionStatus[] = [
+  "successful", "successful", "successful", "pending", "failed", "successful",
+];
+const HASHES = [
+  "a1b2c3d4e5f6789012345678901234567890123456789012345678901234abcd",
+  "b2c3d4e5f6789012345678901234567890123456789012345678901234abcde",
+  "c3d4e5f6789012345678901234567890123456789012345678901234abcdef",
+  "d4e5f6789012345678901234567890123456789012345678901234abcdef01",
+  "e5f6789012345678901234567890123456789012345678901234abcdef0123",
+  "f6789012345678901234567890123456789012345678901234abcdef012345",
+];
+const AMOUNTS = [50.25, 1000.0, 200.5, 75.0, 150.75, 500.0];
+
+export const MOCK_TRANSACTIONS: TransactionFixture[] = Array.from({ length: 38 }, (_, i) => {
+  const idx = i % 6;
+  const date = new Date(2026, 2, 27 - i * 2);
+  return {
+    id: i + 1,
+    transaction_hash: HASHES[idx].slice(0, 24) + i.toString().padStart(4, "0"),
+    amount: AMOUNTS[idx],
+    transaction_type: TYPES[idx],
+    status: STATUSES[idx],
+    policy_id: idx % 2 === 0 ? Math.floor(i / 2) + 1 : null,
+    claim_id: idx === 1 ? i + 1 : null,
+    created_at: date.toISOString(),
+  };
+});


### PR DESCRIPTION
Summary

Resolves four frontend issues for StellarInsure: error logging adapter, auth/session context
placeholder, mock data fixtures, and custom 404/500 error pages.

Closes #161
Closes #157
Closes #158
Closes #163

---

Changes

**#161 — Frontend error logging adapter**

* New: `src/lib/error-logger.ts` — thin adapter with `logError` and `logMessage` exports; routes to Sentry
  when available, falls back to console otherwise. Accepts `ErrorLogContext` with `componentStack`, `tags`,
  and `extra`.
* Updated: `src/components/error-boundary.tsx` — removed inline Sentry require wiring; now delegates to
  `logError`.
* Updated: `src/components/error-boundary.test.tsx` — mock updated to target `@/lib/error-logger` directly.
* New: `src/lib/error-logger.test.ts` — 6 tests covering componentStack forwarding, tags/extra
  passthrough, default log level, and no-throw on plain calls.

**#157 — Auth/session context placeholder**

* New: `src/context/auth-context.tsx` — `AuthProvider` + `useAuth` hook. Tracks `SessionStatus` (loading /
  authenticated / unauthenticated), `UserSession` shape, and `signIn` / `signOut` with `sessionStorage`
  persistence. Follows the same pattern as `WalletProvider`.
* Updated: `src/app/layout.tsx` — `AuthProvider` wrapped around `WalletProvider` inside `LanguageProvider`.
* New: `src/context/auth-context.test.tsx` — 5 tests: unauthenticated default, session restore from
  storage, signIn flow, signOut flow, hook-outside-provider guard.

**#158 — Mock data fixtures for UI development**

* New: `src/lib/fixtures/policies.ts` — 6 typed `PolicyFixture` records across all policy types and
  statuses.
* New: `src/lib/fixtures/claims.ts` — 3 `ClaimFixture` records (Approved, Pending, Rejected) with full
  evidence, review events, and lifecycle events.
* New: `src/lib/fixtures/transactions.ts` — 38 `TransactionFixture` entries matching the history page's
  existing shape.
* New: `src/lib/fixtures/index.ts` — barrel re-export of all three fixture modules.

**#163 — Custom 404 and 500 error pages**

* New: `src/app/not-found.tsx` — Next.js 14 not-found page. Branded 404 with "Go to home" and "View
  policies" recovery links, and a support mailto.
* New: `src/app/error.tsx` — Next.js 14 error page (`"use client"`). Branded 500 with "Try again" (calls
  `reset()`) and "Go to home" links, and support mailto. Logs the error via `logError` on mount. Dev-only
  error detail `<details>` block.
* Updated: `src/app/globals.css` — added `.error-page` block of CSS (card layout, heading, message,
  actions, details, support link) using existing design tokens.

Test plan

* `pnpm test` — all unit tests pass (error-logger, auth-context, error-boundary)
* Navigate to a non-existent URL — branded 404 page appears with recovery links
* Trigger a runtime error in a page — branded 500 page appears with "Try again" and "Go to home"
* Call `useAuth()` from a component inside the app — returns correct session state
* Import `MOCK_POLICIES`, `MOCK_CLAIMS`, `MOCK_TRANSACTIONS` from `@/lib/fixtures` — all exports resolve
  correctly
