### PR TITLE
chore: add standard Node.js cache directories to .gitignore - Closes …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ node_modules/
 out/
 build/
 dist/
+.cache/
+.npm/
+.yarn/
 
 # Environment
 .env


### PR DESCRIPTION
Closes #281

## Summary
Adds standard Node.js cache directories to `.gitignore` to prevent them from being accidentally committed.

## Changes
- `.gitignore` — added `.cache/`, `.npm/`, `.yarn/`

## Type of Change
- [x] Bug fix

## Checklist
- [x] Self-reviewed my own code
- [x] Branch is up to date with `main`