### PR TITLE
fix: standardize error handling, add icon aria-hidden, document contract state vars

### DIFF
--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -73,6 +73,11 @@ class InvalidFileTypeError(StellarInsureError):
     def __init__(self, detail: str = "File type not allowed"):
         super().__init__(status.HTTP_400_BAD_REQUEST, detail, "STORAGE_004")
 
+# Authorization Errors (AUTHZ_xxx)
+class NotAuthorizedError(StellarInsureError):
+    def __init__(self, detail: str = "Not authorized to perform this action"):
+        super().__init__(status.HTTP_403_FORBIDDEN, detail, "AUTHZ_001")
+
 # Validation Errors (VAL_xxx)
 class ValidationError(StellarInsureError):
     def __init__(self, detail: str, error_code: str = "VAL_001"):

--- a/backend/src/routes/storage.py
+++ b/backend/src/routes/storage.py
@@ -1,13 +1,13 @@
 import os
 from sqlalchemy.orm import Session
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import FileResponse
 from ..database import get_db
 from ..models import User, Claim
 from ..schemas import MessageResponse
 from ..dependencies import get_current_active_user
 from ..services.storage_service import storage_service
-from ..errors import FileNotFoundStorageError, InvalidStorageTokenError
+from ..errors import ClaimNotFoundError, FileNotFoundStorageError, InvalidStorageTokenError, NotAuthorizedError
 
 router = APIRouter(prefix="/storage", tags=["storage"])
 
@@ -57,10 +57,10 @@ async def delete_file(
 ):
     claim = db.query(Claim).filter(Claim.id == claim_id).first()
     if not claim:
-        raise HTTPException(status_code=404, detail="Claim not found")
-        
+        raise ClaimNotFoundError()
+
     if claim.claimant_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to delete this file")
+        raise NotAuthorizedError("Not authorized to delete this file")
         
     # Delete file from storage
     storage_service.delete_file(claim.proof)

--- a/frontend/src/components/icon.tsx
+++ b/frontend/src/components/icon.tsx
@@ -53,6 +53,7 @@ type IconProps = {
   tone?: IconTone;
   label?: string;
   className?: string;
+  "aria-hidden"?: boolean | "true" | "false";
 };
 
 const sizeMap: Record<IconSize, number> = {
@@ -321,9 +322,11 @@ export function Icon({
   tone = "default",
   label,
   className,
+  "aria-hidden": ariaHiddenProp,
 }: IconProps) {
   const dimension = sizeMap[size];
-  const ariaHidden = label ? undefined : true;
+  // Explicit aria-hidden prop takes precedence; fall back to hiding when no label
+  const ariaHidden = ariaHiddenProp !== undefined ? ariaHiddenProp : (label ? undefined : true);
 
   return (
     <svg

--- a/smartcontract/src/storage.rs
+++ b/smartcontract/src/storage.rs
@@ -2,33 +2,104 @@ use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 use crate::{Claim, ClaimVotes, Error, Policy, PoolStats, ProviderPosition, Providers};
 
+/// Enumeration of all persistent and instance storage keys used by the contract.
+///
+/// Storage tiers:
+/// - **Instance** (`env.storage().instance()`): shared across all invocations of the
+///   contract instance; suitable for small, frequently-read values (admin, counters,
+///   global flags).
+/// - **Persistent** (`env.storage().persistent()`): per-key TTL-extended storage;
+///   used for per-policy, per-claim, and per-provider data that must survive ledger
+///   expiry extensions.
 #[contracttype]
 enum DataKey {
+    /// The primary administrator address. Used for privileged operations before
+    /// multi-sig support was added; kept for legacy fallback in `is_admin`.
     Admin,
+
+    /// Monotonically increasing counter that tracks the total number of policies
+    /// ever created. Used to assign unique policy IDs.
     PolicyCounter,
+
+    /// Per-policy storage keyed by the policy's numeric ID.
     Policy(u64),
+
+    /// Per-claim storage keyed by the associated policy ID.
+    /// Each policy may have at most one active claim record.
     Claim(u64),
+
+    /// The Stellar token contract address used for premium payments and claim payouts.
+    /// Must be set by the admin via `set_premium_token` before policies can be created.
     PremiumToken,
+
+    /// Administrator address for the risk pool contract.
+    /// Authorised to call liquidity management functions on the pool.
     RiskPoolAdmin,
+
+    /// Aggregate XLM (or token) liquidity currently held in the risk pool.
+    /// Updated on every deposit and withdrawal.
     TotalLiquidity,
+
+    /// Cumulative yield (premiums) distributed to liquidity providers since
+    /// the contract was initialised.
     TotalYieldDistributed,
+
+    /// Per-provider liquidity position keyed by the provider's `Address`.
     Provider(Address),
+
+    /// Ordered list of all registered liquidity provider addresses.
+    /// Maintained alongside individual `Provider` entries so the pool can
+    /// iterate over providers when distributing yield.
     Providers,
+
+    /// Global pause flag. When `true`, policy creation and claim submission
+    /// are blocked. Set by the admin via `pause` / `unpause`.
     Paused,
+
     // Issue #16 — multi-sig
+    /// List of addresses that collectively form the multi-sig admin set.
+    /// Any address in this list may perform admin-gated operations.
     Admins,
+
+    /// Minimum number of admin approvals required to execute a multi-sig action.
     Threshold,
+
+    /// Accumulated approval/rejection votes for a pending claim, keyed by policy ID.
+    /// Cleared once the claim reaches the required threshold.
     ClaimVotes(u64),
+
+    /// Contract schema version. Incremented on breaking storage migrations so
+    /// upgrade logic can detect and apply the correct migration path.
     Version,
+
+    /// Cumulative total of all premiums collected by the protocol since deployment.
     TotalPremium,
+
+    /// Cumulative total of all claim payouts disbursed by the protocol since deployment.
     TotalPayouts,
+
+    /// Address of the external risk pool contract that holds liquidity and
+    /// executes payouts on behalf of the main insurance contract.
     RiskPool,
+
     // Issue #199 — max policies
+    /// Hard cap on the number of policies that may exist simultaneously.
+    /// Defaults to `MAX_POLICIES` (1 000 000) and can be adjusted by the admin.
     MaxPolicies,
+
     // Issue #202 — reserve ratio
+    /// Minimum reserve ratio expressed in basis points (e.g. 2000 = 20 %).
+    /// The pool must maintain at least this fraction of total liquidity as
+    /// unencumbered reserves before a payout can be approved.
     ReserveRatio,
+
     // Issue #198 — oracle integration
+    /// Oracle contract address for a specific oracle type, keyed by a `Symbol`
+    /// identifier (e.g. `"weather"`, `"flight"`).
     OracleAddress(Symbol),
+
+    /// Ordered list of all oracle type `Symbol`s that have been registered.
+    /// Used to enumerate active oracles without requiring off-chain indexing.
     OracleAddresses,
 }
 


### PR DESCRIPTION

- fix(#277): replace raw HTTPException with typed error classes in storage route
  - add NotAuthorizedError (AUTHZ_001) to errors.py
  - use ClaimNotFoundError and NotAuthorizedError in routes/storage.py
- fix(#276): add aria-hidden prop to Icon component so callers can explicitly mark decorative icons as hidden from assistive technology
- fix(#279): add detailed inline doc-comments to all DataKey variants in smartcontract/src/storage.rs explaining purpose, storage tier, and defaults


## Linked issues
- Closes #276
- Closes #277
- Closes #279

