### PR TITLE
feat(policies): fix aria labels, remove any types, persist view mode, add result count

### DIFF
--- a/frontend/src/app/policies/policies-list-page-client.test.tsx
+++ b/frontend/src/app/policies/policies-list-page-client.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LanguageProvider } from "@/i18n/provider";
+import PoliciesListPageClient from "./policies-list-page-client";
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<LanguageProvider>{ui}</LanguageProvider>);
+}
+
+describe("PoliciesListPageClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it("defaults to grid view on first visit", () => {
+    renderWithProviders(<PoliciesListPageClient />);
+    expect(screen.getByRole("button", { name: /grid view/i })).toHaveClass("active");
+  });
+
+  it("restores table view mode from localStorage on mount", async () => {
+    localStorage.setItem("policy-view-mode", "table");
+    renderWithProviders(<PoliciesListPageClient />);
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(screen.getByRole("button", { name: /table view/i })).toHaveClass("active");
+  });
+
+  it("persists grid view selection to localStorage", () => {
+    localStorage.setItem("policy-view-mode", "table");
+    renderWithProviders(<PoliciesListPageClient />);
+    act(() => {
+      vi.runAllTimers();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /grid view/i }));
+    expect(localStorage.getItem("policy-view-mode")).toBe("grid");
+  });
+
+  it("persists table view selection to localStorage", () => {
+    renderWithProviders(<PoliciesListPageClient />);
+    fireEvent.click(screen.getByRole("button", { name: /table view/i }));
+    expect(localStorage.getItem("policy-view-mode")).toBe("table");
+  });
+
+  it("shows policy result count after loading", () => {
+    renderWithProviders(<PoliciesListPageClient />);
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(screen.getByText(/policies found/i)).toBeInTheDocument();
+  });
+
+  it("result count updates when filters change", () => {
+    renderWithProviders(<PoliciesListPageClient />);
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    const initialCount = screen.getByText(/policies found/i).textContent;
+    fireEvent.change(screen.getByLabelText(/status/i), { target: { value: "active" } });
+    act(() => {
+      vi.runAllTimers();
+    });
+    const updatedCount = screen.getByText(/policies found/i).textContent;
+    expect(updatedCount).not.toBe(initialCount);
+  });
+});

--- a/frontend/src/app/policies/policies-list-page-client.tsx
+++ b/frontend/src/app/policies/policies-list-page-client.tsx
@@ -243,6 +243,13 @@ export default function PoliciesListPageClient() {
   const [viewMode, setViewMode] = useState<"grid" | "table">("grid");
   const [isLoading, setIsLoading] = useState(true);
 
+  useEffect(() => {
+    const stored = localStorage.getItem("policy-view-mode");
+    if (stored === "table" || stored === "grid") {
+      setViewMode(stored);
+    }
+  }, []);
+
   // Optimistic list — new policies appear immediately before server confirmation
   const {
     items: optimisticPolicies,
@@ -378,14 +385,20 @@ export default function PoliciesListPageClient() {
         <div className="view-toggle">
           <button
             className={`view-toggle-btn ${viewMode === "grid" ? "active" : ""}`}
-            onClick={() => setViewMode("grid")}
+            onClick={() => {
+              setViewMode("grid");
+              localStorage.setItem("policy-view-mode", "grid");
+            }}
             aria-label="Grid view"
           >
             <Icon name="grid-3x3" size="sm" />
           </button>
           <button
             className={`view-toggle-btn ${viewMode === "table" ? "active" : ""}`}
-            onClick={() => setViewMode("table")}
+            onClick={() => {
+              setViewMode("table");
+              localStorage.setItem("policy-view-mode", "table");
+            }}
             aria-label="Table view"
           >
             <Icon name="list" size="sm" />
@@ -507,6 +520,15 @@ export default function PoliciesListPageClient() {
             </option>
           </select>
         </div>
+
+        {!isLoading && (
+          <p className="tx-result-count" aria-live="polite" aria-atomic="true">
+            {sorted.length} {t("policies.filters.found")}
+          </p>
+        )}
+        <p className="tx-filtering" aria-live="polite" role="status">
+          {isFiltering ? t("policies.filters.updating") : t("policies.filters.upToDate")}
+        </p>
       </div>
 
       {isLoading ? (

--- a/frontend/src/components/policy-table.test.tsx
+++ b/frontend/src/components/policy-table.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PolicyTable, type Policy } from "./policy-table";
+
+const MOCK_POLICIES: Policy[] = [
+  {
+    id: "policy-b",
+    title: "Policy B",
+    type: "weather",
+    status: "active",
+    coverageAmount: 5000,
+    premiumAmount: 125.5,
+    createdAt: "2026-02-15",
+    expiresAt: "2026-06-01",
+    oracleSource: "NOAA",
+  },
+  {
+    id: "policy-a",
+    title: "Policy A",
+    type: "flight",
+    status: "pending",
+    coverageAmount: 2000,
+    premiumAmount: 45.0,
+    createdAt: "2026-03-01",
+    expiresAt: "2026-05-01",
+    oracleSource: "Airline API",
+  },
+];
+
+describe("PolicyTable", () => {
+  it("renders an empty state when no policies are provided", () => {
+    render(<PolicyTable policies={[]} />);
+    expect(screen.getByText("No policies found.")).toBeInTheDocument();
+  });
+
+  it("renders policy rows", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    expect(screen.getByText("policy-b")).toBeInTheDocument();
+    expect(screen.getByText("policy-a")).toBeInTheDocument();
+  });
+
+  it("sort button aria-label reflects unsorted state", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    expect(
+      screen.getByRole("button", { name: /sort by premium/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("sort button aria-label updates after toggling sort on a column", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    const coverageBtn = screen.getByRole("button", { name: /sort by coverage/i });
+    fireEvent.click(coverageBtn);
+    expect(
+      screen.getByRole("button", { name: /coverage, sorted ascending\. click to sort descending/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles sort order and updates aria-label on second click", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    const premiumBtn = screen.getByRole("button", { name: /sort by premium/i });
+    fireEvent.click(premiumBtn);
+    fireEvent.click(premiumBtn);
+    expect(
+      screen.getByRole("button", { name: /premium, sorted descending\. click to sort ascending/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("sorts policies by coverage ascending when coverage column is clicked", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    fireEvent.click(screen.getByRole("button", { name: /sort by coverage/i }));
+    const rows = screen.getAllByRole("row").slice(1);
+    const amounts = rows.map((r) => r.querySelector("td:nth-child(3)")?.textContent);
+    expect(amounts[0]).toContain("2000");
+    expect(amounts[1]).toContain("5000");
+  });
+
+  it("sorts policies by coverage descending on second click", () => {
+    render(<PolicyTable policies={MOCK_POLICIES} />);
+    const btn = screen.getByRole("button", { name: /sort by coverage/i });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    const rows = screen.getAllByRole("row").slice(1);
+    const amounts = rows.map((r) => r.querySelector("td:nth-child(3)")?.textContent);
+    expect(amounts[0]).toContain("5000");
+    expect(amounts[1]).toContain("2000");
+  });
+});

--- a/frontend/src/components/policy-table.tsx
+++ b/frontend/src/components/policy-table.tsx
@@ -31,8 +31,8 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
     const sortedPolicies = useMemo(() => {
         const copy = [...policies];
         copy.sort((a, b) => {
-            let valA: any = "";
-            let valB: any = "";
+            let valA: string | number = "";
+            let valB: string | number = "";
 
             switch (sortField) {
                 case "id":
@@ -73,25 +73,29 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
         }
     };
 
-    const SortIcon = ({ field }: { field: SortField }) => {
-        const getAriaLabel = (f: SortField): string => {
-            const fieldNames: Record<SortField, string> = {
-                id: "Policy ID",
-                premium: "Premium",
-                coverage: "Coverage",
-                expiry: "Expiry",
-                status: "Status",
-            };
-            const fieldName = fieldNames[f];
-            if (sortField !== f) return `Sort by ${fieldName}`;
-            return sortOrder === "asc" ? `${fieldName}, sorted ascending` : `${fieldName}, sorted descending`;
-        };
+    const fieldNames: Record<SortField, string> = {
+        id: "Policy ID",
+        premium: "Premium",
+        coverage: "Coverage",
+        expiry: "Expiry",
+        status: "Status",
+    };
 
-        if (sortField !== field) return <Icon name="chevron-up-down" size="sm" tone="muted" label={getAriaLabel(field)} />;
+    const getSortButtonAriaLabel = (field: SortField): string => {
+        const name = fieldNames[field];
+        if (sortField !== field) return `Sort by ${name}`;
+        return sortOrder === "asc"
+            ? `${name}, sorted ascending. Click to sort descending`
+            : `${name}, sorted descending. Click to sort ascending`;
+    };
+
+    const SortIcon = ({ field }: { field: SortField }) => {
+        const iconLabel = fieldNames[field];
+        if (sortField !== field) return <Icon name="chevron-up-down" size="sm" tone="muted" label={iconLabel} />;
         return sortOrder === "asc" ? (
-            <Icon name="chevron-up" size="sm" tone="accent" label={getAriaLabel(field)} />
+            <Icon name="chevron-up" size="sm" tone="accent" label={iconLabel} />
         ) : (
-            <Icon name="chevron-down" size="sm" tone="accent" label={getAriaLabel(field)} />
+            <Icon name="chevron-down" size="sm" tone="accent" label={iconLabel} />
         );
     };
 
@@ -113,7 +117,7 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
                             <button
                                 onClick={() => toggleSort("id")}
                                 className="sort-button"
-                                aria-label="Sort by Policy ID, currently sorted ascending"
+                                aria-label={getSortButtonAriaLabel("id")}
                             >
                                 Policy ID <SortIcon field="id" />
                             </button>
@@ -122,7 +126,7 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
                             <button
                                 onClick={() => toggleSort("premium")}
                                 className="sort-button"
-                                aria-label="Sort by Premium"
+                                aria-label={getSortButtonAriaLabel("premium")}
                             >
                                 Premium <SortIcon field="premium" />
                             </button>
@@ -131,7 +135,7 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
                             <button
                                 onClick={() => toggleSort("coverage")}
                                 className="sort-button"
-                                aria-label="Sort by Coverage"
+                                aria-label={getSortButtonAriaLabel("coverage")}
                             >
                                 Coverage <SortIcon field="coverage" />
                             </button>
@@ -140,7 +144,7 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
                             <button
                                 onClick={() => toggleSort("expiry")}
                                 className="sort-button"
-                                aria-label="Sort by Expiry"
+                                aria-label={getSortButtonAriaLabel("expiry")}
                             >
                                 Expiry <SortIcon field="expiry" />
                             </button>
@@ -149,7 +153,7 @@ export function PolicyTable({ policies, isLoading }: PolicyTableProps) {
                             <button
                                 onClick={() => toggleSort("status")}
                                 className="sort-button"
-                                aria-label="Sort by Status"
+                                aria-label={getSortButtonAriaLabel("status")}
                             >
                                 Status <SortIcon field="status" />
                             </button>

--- a/frontend/src/i18n/messages/ar.ts
+++ b/frontend/src/i18n/messages/ar.ts
@@ -241,6 +241,9 @@ const ar = {
       allTypes: "جميع الأنواع",
       newestFirst: "الأحدث أولاً",
       highestCoverage: "أعلى تغطية",
+      found: "وثائق وجدت",
+      updating: "جارٍ تحديث النتائج...",
+      upToDate: "المرشحات محدثة.",
     },
     empty: {
       title: "لم يتم العثور على وثائق",

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -212,6 +212,9 @@ const en = {
       sortBy: "Sort By",
       newestFirst: "Newest First",
       highestCoverage: "Highest Coverage",
+      found: "policies found",
+      updating: "Updating results...",
+      upToDate: "Filters are up to date.",
     },
     empty: {
       title: "No policies found",


### PR DESCRIPTION
## Summary

- **#312 – Fix sortable policy table aria labels**: `getSortButtonAriaLabel` now derives each sort button's `aria-label` from the live `sortField` and `sortOrder` state, so screen readers always announce the current column sort direction and what the next click will do.
- **#313 – Remove `any` from policy table sorting**: Replaced `let valA: any` / `let valB: any` with `let valA: string | number` / `let valB: string | number`; `npm run type-check` passes with no new errors in the changed files.
- **#310 – Preserve policy list view mode across visits**: `viewMode` is written to `localStorage` on every toggle and restored inside a `useEffect` on mount, avoiding SSR hydration mismatches; first-time visitors still see the grid default.
- **#316 – Add policy result count near filters**: Added a `aria-live="polite"` result count and filter-status paragraph inside the filter bar, mirroring the transaction history count pattern (`tx-result-count` / `tx-filtering`); count is hidden during initial loading and updates as deferred filter values resolve.

Closes #310 
closes #312 
closes #313 
closes #316