### PR TITLE
fix: resolve issues #317, #324, #325, #326

### DIFF
--- a/frontend/src/app/create/create-page-client.tsx
+++ b/frontend/src/app/create/create-page-client.tsx
@@ -327,6 +327,8 @@ export default function CreatePolicyPageClient() {
   });
   const [txSteps, setTxSteps] = useState<TimelineStep[]>(DEFAULT_TX_STEPS);
   const [coverageTouched, setCoverageTouched] = useState(false);
+  const [premiumTouched, setPremiumTouched] = useState(false);
+  const [durationTouched, setDurationTouched] = useState(false);
   const [oracleState, setOracleState] = useState<OracleProviderState>("loading");
   const [oracleProviders, setOracleProviders] = useState<OracleProvider[]>([]);
   const [oracleReloadCounter, setOracleReloadCounter] = useState(0);
@@ -386,13 +388,15 @@ export default function CreatePolicyPageClient() {
 
   function handleConfigureNext() {
     setCoverageTouched(true);
+    setPremiumTouched(true);
+    setDurationTouched(true);
 
     const errors: ValidationError[] = [];
     if (coverageError) errors.push({ id: "coverage-input", field: "Coverage", message: coverageError });
     if (draft.triggerCondition.trim() === "")
       errors.push({ id: "trigger-input", field: "Trigger", message: "Trigger condition is required." });
-    if (draft.premium.trim() === "") errors.push({ id: "premium-input", field: "Premium", message: "Premium is required." });
-    if (draft.duration.trim() === "") errors.push({ id: "duration-input", field: "Duration", message: "Duration is required." });
+    if (premiumError) errors.push({ id: "premium-input", field: "Premium", message: premiumError });
+    if (durationError) errors.push({ id: "duration-input", field: "Duration", message: durationError });
     if (oracleState !== "ready" || draft.oracleProvider.trim() === "")
       errors.push({ id: "oracle-selector", field: "Oracle", message: "Please select an oracle provider." });
 
@@ -489,6 +493,20 @@ export default function CreatePolicyPageClient() {
           ? `Coverage amount cannot exceed ${formatAssetAmount(MAX_COVERAGE_AMOUNT)} XLM.`
           : undefined;
 
+  const premiumError =
+    draft.premium.trim() === ""
+      ? "Premium is required."
+      : isNaN(Number(draft.premium)) || Number(draft.premium) <= 0
+        ? "Enter a positive numeric premium value."
+        : undefined;
+
+  const durationError =
+    draft.duration.trim() === ""
+      ? "Duration is required."
+      : isNaN(Number(draft.duration)) || Number(draft.duration) <= 0
+        ? "Enter a positive number of days."
+        : undefined;
+
   const selectedOracle = useMemo(
     () => oracleProviders.find((provider) => provider.id === draft.oracleProvider),
     [draft.oracleProvider, oracleProviders],
@@ -496,9 +514,9 @@ export default function CreatePolicyPageClient() {
 
   const isConfigValid =
     coverageError === undefined &&
+    premiumError === undefined &&
+    durationError === undefined &&
     draft.triggerCondition.trim() !== "" &&
-    draft.premium.trim() !== "" &&
-    draft.duration.trim() !== "" &&
     oracleState === "ready" &&
     draft.oracleProvider.trim() !== "";
 
@@ -566,9 +584,15 @@ export default function CreatePolicyPageClient() {
                 step="0.01"
                 placeholder="e.g. 200"
                 value={draft.premium}
+                aria-invalid={Boolean(premiumError) && premiumTouched}
+                aria-describedby={premiumError && premiumTouched ? "premium-error" : "premium-hint"}
                 onChange={(event) => updateDraft("premium", event.target.value)}
+                onBlur={() => setPremiumTouched(true)}
               />
-              <span className="field__hint">{t("createPolicy.configSection.premiumHint")}</span>
+              <span id="premium-hint" className="field__hint">{t("createPolicy.configSection.premiumHint")}</span>
+              {premiumError && premiumTouched ? (
+                <span id="premium-error" className="field__error">{premiumError}</span>
+              ) : null}
 
               <div style={{ marginTop: "var(--space-4)" }}>
                 <PremiumEstimate
@@ -601,13 +625,13 @@ export default function CreatePolicyPageClient() {
 
             <label className="field">
               <span className="field__label">{t("createPolicy.configSection.durationLabel")}</span>
-              <div style={{ display: "flex", gap: "var(--space-2)", marginBottom: "var(--space-2)", flexWrap: "wrap" }}>
+              <div className="duration-presets">
                 {[30, 90, 180, 365].map((days) => (
                   <button
                     key={days}
                     type="button"
-                    className="cta-secondary"
-                    style={draft.duration === String(days) ? { borderColor: "var(--color-primary)", background: "var(--color-surface)", color: "var(--color-primary)" } : {}}
+                    className={`cta-secondary${draft.duration === String(days) ? " duration-preset-btn--selected" : ""}`}
+                    aria-pressed={draft.duration === String(days)}
                     onClick={() => updateDraft("duration", String(days))}
                   >
                     {days} Days
@@ -621,9 +645,15 @@ export default function CreatePolicyPageClient() {
                 min="1"
                 placeholder="e.g. custom duration days"
                 value={draft.duration}
+                aria-invalid={Boolean(durationError) && durationTouched}
+                aria-describedby={durationError && durationTouched ? "duration-error" : "duration-hint"}
                 onChange={(event) => updateDraft("duration", event.target.value)}
+                onBlur={() => setDurationTouched(true)}
               />
-              <span className="field__hint">{t("createPolicy.configSection.durationHint")}</span>
+              <span id="duration-hint" className="field__hint">{t("createPolicy.configSection.durationHint")}</span>
+              {durationError && durationTouched ? (
+                <span id="duration-error" className="field__error">{durationError}</span>
+              ) : null}
             </label>
           </div>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1841,6 +1841,19 @@ dt,
   padding: 2rem 0 3rem;
 }
 
+.duration-presets {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.duration-preset-btn--selected {
+  border-color: var(--accent-strong);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
 .create-section {
   display: grid;
   gap: var(--space-4);

--- a/frontend/src/app/policies/policies-list-page-client.tsx
+++ b/frontend/src/app/policies/policies-list-page-client.tsx
@@ -262,6 +262,8 @@ export default function PoliciesListPageClient() {
   const [endDate, setEndDate] = useState<string>(INITIAL_FILTERS.endDate);
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
   const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const PAGE_SIZE = 6;
 
   useEffect(() => {
     const stored = localStorage.getItem('policy-view-mode');
@@ -417,6 +419,13 @@ export default function PoliciesListPageClient() {
       setEndDate(INITIAL_FILTERS.endDate);
     });
   }
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [statusFilter, typeFilter, sortBy, minCoverage, maxCoverage, startDate, endDate]);
+
+  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const paged = sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   return (
     <main id="main-content" tabIndex={-1} className="policy-page">
@@ -620,28 +629,102 @@ export default function PoliciesListPageClient() {
           </Link>
         </div>
       ) : viewMode === 'grid' ? (
-        <div
-          className={`policy-grid motion-panel ${isFiltering ? 'policy-grid--loading' : ''}`}
-        >
-          {sorted.map((entry) => (
-            <PolicyCard
-              key={entry.data.id}
-              policy={entry.data}
-              optimisticStatus={entry.optimisticStatus}
-              onDismissError={
-                entry.optimisticStatus === 'error'
-                  ? () => removeItem(entry.data.id)
-                  : undefined
-              }
-            />
-          ))}
-        </div>
+        <>
+          <div
+            className={`policy-grid motion-panel ${isFiltering ? 'policy-grid--loading' : ''}`}
+          >
+            {paged.map((entry) => (
+              <PolicyCard
+                key={entry.data.id}
+                policy={entry.data}
+                optimisticStatus={entry.optimisticStatus}
+                onDismissError={
+                  entry.optimisticStatus === 'error'
+                    ? () => removeItem(entry.data.id)
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <nav className="tx-pagination" aria-label="Policy pages">
+              <p className="sr-only" aria-live="polite" aria-atomic="true">
+                Page {currentPage} of {totalPages}
+              </p>
+              <button
+                className="tx-page-btn"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((p) => p - 1)}
+                aria-label="Previous page"
+              >
+                ‹
+              </button>
+              <span className="tx-page-numbers">
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                  <button
+                    key={page}
+                    className={`tx-page-btn${currentPage === page ? ' tx-page-btn--active' : ''}`}
+                    onClick={() => setCurrentPage(page)}
+                    aria-current={currentPage === page ? 'page' : undefined}
+                  >
+                    {page}
+                  </button>
+                ))}
+              </span>
+              <button
+                className="tx-page-btn"
+                disabled={currentPage === totalPages}
+                onClick={() => setCurrentPage((p) => p + 1)}
+                aria-label="Next page"
+              >
+                ›
+              </button>
+            </nav>
+          )}
+        </>
       ) : (
-        <div
-          className={`policy-table-view motion-panel ${isFiltering ? 'policy-grid--loading' : ''}`}
-        >
-          <PolicyTable policies={sorted.map((e) => e.data) as any} />
-        </div>
+        <>
+          <div
+            className={`policy-table-view motion-panel ${isFiltering ? 'policy-grid--loading' : ''}`}
+          >
+            <PolicyTable policies={paged.map((e) => e.data) as any} />
+          </div>
+          {totalPages > 1 && (
+            <nav className="tx-pagination" aria-label="Policy pages">
+              <p className="sr-only" aria-live="polite" aria-atomic="true">
+                Page {currentPage} of {totalPages}
+              </p>
+              <button
+                className="tx-page-btn"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((p) => p - 1)}
+                aria-label="Previous page"
+              >
+                ‹
+              </button>
+              <span className="tx-page-numbers">
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                  <button
+                    key={page}
+                    className={`tx-page-btn${currentPage === page ? ' tx-page-btn--active' : ''}`}
+                    onClick={() => setCurrentPage(page)}
+                    aria-current={currentPage === page ? 'page' : undefined}
+                  >
+                    {page}
+                  </button>
+                ))}
+              </span>
+              <button
+                className="tx-page-btn"
+                disabled={currentPage === totalPages}
+                onClick={() => setCurrentPage((p) => p + 1)}
+                aria-label="Next page"
+              >
+                ›
+              </button>
+            </nav>
+          )}
+        </>
       )}
     </main>
   );


### PR DESCRIPTION
- #324: prefers-reduced-motion already disables smooth scroll (no-op)
- #325: replace inline styles on duration preset buttons with CSS classes (.duration-presets, .duration-preset-btn--selected); add aria-pressed
- #326: validate premium and duration as positive numeric values with inline errors and aria-invalid/aria-describedby attributes
- #317: add client-side pagination (PAGE_SIZE=6) to policy list; resets on filter change; shared controls for grid and table views; page info announced politely via sr-only aria-live region

## Summary
- What changed and why?

## Linked issues
- Closes #317 
- Closes #324 
- Closes #325 
- Closes #326 
- 

## Test plan
- [ ] Frontend tests pass (`npm test` in `frontend`)
- [ ] Backend tests pass (`pytest` in `backend`)
- [ ] Smart contract tests pass (`cargo test` in `smartcontract`)
- [ ] Manually validated affected flows

## Checklist
- [ ] Code follows project style conventions
- [ ] New/updated tests cover the change
- [ ] Docs updated when behavior changed
- [ ] No secrets or credentials added
