### PR TITLE
[codex] Preserve trigger condition draft value

### DIFF
--- a/frontend/src/app/create/create-page-client.test.tsx
+++ b/frontend/src/app/create/create-page-client.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LanguageProvider } from "@/i18n/provider";
 import CreatePolicyPageClient from "./create-page-client";
 
 vi.mock("@/components/wallet-provider", () => ({
@@ -18,12 +19,19 @@ vi.mock("@stellar/freighter-api", () => ({
 }));
 
 vi.mock("@/components/trigger-condition-builder", () => ({
-  TriggerConditionBuilder: ({ onChange }: { onChange: (value: string) => void }) => (
+  TriggerConditionBuilder: ({
+    value = "",
+    onChange,
+  }: {
+    value?: string;
+    onChange: (value: string) => void;
+  }) => (
     <input
       aria-label="Trigger mock input"
       onChange={(event) => onChange(event.target.value)}
       placeholder="Trigger mock input"
       type="text"
+      value={value}
     />
   ),
 }));
@@ -53,27 +61,63 @@ vi.mock("@/components/oracle-source-selector", () => ({
     ),
 }));
 
+function makeTestStorage() {
+  let store: Record<string, string> = {};
+
+  return {
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+}
+
+const testStorage = makeTestStorage();
+
+function renderCreatePolicyPage() {
+  return render(
+    <LanguageProvider>
+      <CreatePolicyPageClient />
+    </LanguageProvider>,
+  );
+}
+
 describe("CreatePolicyPageClient", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     signTransactionMock.mockResolvedValue({ signedTxXdr: "signed-xdr" });
+    testStorage.clear();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: testStorage,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: testStorage,
+    });
     window.scrollTo = vi.fn();
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    localStorage.clear();
+    testStorage.clear();
   });
 
   it("moves from policy type selection into configure step", () => {
-    render(<CreatePolicyPageClient />);
+    renderCreatePolicyPage();
     fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
 
     expect(screen.getByRole("heading", { name: /configure your policy/i })).toBeInTheDocument();
   });
 
   it("applies form validation for invalid coverage values", () => {
-    render(<CreatePolicyPageClient />);
+    renderCreatePolicyPage();
     fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
 
     const coverageInput = screen.getByLabelText(/coverage amount/i);
@@ -84,8 +128,37 @@ describe("CreatePolicyPageClient", () => {
     expect(screen.getByRole("button", { name: /continue to review/i })).toBeDisabled();
   });
 
+  it("restores trigger condition into the builder and keeps autosave working", () => {
+    testStorage.setItem(
+      "stellarinsure-policy-draft",
+      JSON.stringify({
+        policyType: "weather",
+        coverageAmount: "",
+        premium: "",
+        triggerCondition: "rainfall > 50",
+        duration: "",
+        oracleProvider: "",
+      }),
+    );
+    renderCreatePolicyPage();
+
+    expect(screen.getByRole("heading", { name: /configure your policy/i })).toBeInTheDocument();
+
+    const triggerInput = screen.getByLabelText(/trigger mock input/i);
+    expect(triggerInput).toHaveValue("rainfall > 50");
+
+    fireEvent.change(triggerInput, { target: { value: "rainfall > 60" } });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(JSON.parse(testStorage.getItem("stellarinsure-policy-draft") ?? "{}")).toMatchObject({
+      triggerCondition: "rainfall > 60",
+    });
+  });
+
   it("submits successfully with mocked wallet signature", async () => {
-    localStorage.setItem(
+    testStorage.setItem(
       "stellarinsure-policy-draft",
       JSON.stringify({
         policyType: "weather",
@@ -96,7 +169,7 @@ describe("CreatePolicyPageClient", () => {
         oracleProvider: "weatherlink-prime",
       }),
     );
-    render(<CreatePolicyPageClient />);
+    renderCreatePolicyPage();
 
     expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
 

--- a/frontend/src/app/create/create-page-client.tsx
+++ b/frontend/src/app/create/create-page-client.tsx
@@ -616,6 +616,7 @@ export default function CreatePolicyPageClient() {
             <div className="field field--full" id="trigger-input">
               <span className="field__label">{t("createPolicy.configSection.triggerLabel")}</span>
               <TriggerConditionBuilder
+                value={draft.triggerCondition}
                 onChange={(val) => updateDraft("triggerCondition", val)}
               />
               <span className="field__hint">

--- a/frontend/src/components/trigger-condition-builder.tsx
+++ b/frontend/src/components/trigger-condition-builder.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Icon } from "@/components/icon";
 
 export type Operator = ">" | "<" | "=" | ">=" | "<=";
@@ -13,6 +13,7 @@ export interface ConditionRule {
 
 interface TriggerConditionBuilderProps {
   initialRules?: ConditionRule[];
+  value?: string;
   onChange: (conditionString: string) => void;
   availableFields?: { id: string; label: string }[];
 }
@@ -24,14 +25,55 @@ const DEFAULT_FIELDS = [
   { id: "delay_minutes", label: "Delay (minutes)" },
 ];
 
+function createDefaultRule(availableFields: { id: string; label: string }[]): ConditionRule {
+  return { field: availableFields[0]?.id ?? "", operator: ">", value: "" };
+}
+
+function serializeRules(currentRules: ConditionRule[]) {
+  return currentRules
+    .filter((r) => r.value.trim() !== "")
+    .map((r) => `${r.field} ${r.operator} ${r.value}`)
+    .join(" AND ");
+}
+
+function parseConditionValue(
+  conditionString: string,
+  availableFields: { id: string; label: string }[],
+): ConditionRule[] {
+  const parsedRules = conditionString
+    .split(/\s+AND\s+/i)
+    .map((part) => {
+      const match = part.trim().match(/^(\S+)\s*(>=|<=|>|<|=)\s*(.+)$/);
+      if (!match) return null;
+
+      return {
+        field: match[1],
+        operator: match[2] as Operator,
+        value: match[3].trim(),
+      };
+    })
+    .filter((rule): rule is ConditionRule => rule !== null);
+
+  return parsedRules.length > 0 ? parsedRules : [createDefaultRule(availableFields)];
+}
+
 export function TriggerConditionBuilder({
   initialRules,
+  value,
   onChange,
   availableFields = DEFAULT_FIELDS,
 }: TriggerConditionBuilderProps) {
   const [rules, setRules] = useState<ConditionRule[]>(
-    initialRules || [{ field: availableFields[0].id, operator: ">", value: "" }]
+    value !== undefined
+      ? parseConditionValue(value, availableFields)
+      : initialRules || [createDefaultRule(availableFields)]
   );
+  const lastEmittedValueRef = useRef(value);
+
+  useEffect(() => {
+    if (value === undefined || value === lastEmittedValueRef.current) return;
+    setRules(parseConditionValue(value, availableFields));
+  }, [availableFields, value]);
 
   const updateRule = (index: number, updates: Partial<ConditionRule>) => {
     const nextRules = [...rules];
@@ -54,10 +96,8 @@ export function TriggerConditionBuilder({
   };
 
   const notifyChange = (currentRules: ConditionRule[]) => {
-    const str = currentRules
-      .filter((r) => r.value.trim() !== "")
-      .map((r) => `${r.field} ${r.operator} ${r.value}`)
-      .join(" AND ");
+    const str = serializeRules(currentRules);
+    lastEmittedValueRef.current = str;
     onChange(str);
   };
 
@@ -122,10 +162,7 @@ export function TriggerConditionBuilder({
         <span className="metadata-label">Previewed Logic</span>
         <code className="condition-preview__code">
           {rules.filter((r) => r.value.trim() !== "").length > 0
-            ? rules
-                .filter((r) => r.value.trim() !== "")
-                .map((r) => `${r.field} ${r.operator} ${r.value}`)
-                .join(" AND ")
+            ? serializeRules(rules)
             : "No valid conditions set"}
         </code>
       </div>

--- a/frontend/src/components/untested-components.test.tsx
+++ b/frontend/src/components/untested-components.test.tsx
@@ -107,6 +107,17 @@ describe("oracle and trigger controls", () => {
     fireEvent.change(valueInput, { target: { value: "120" } });
     expect(onChange).toHaveBeenCalledWith("temperature > 120");
   });
+
+  it("hydrates trigger condition strings into visible rules", () => {
+    const onChange = vi.fn();
+    render(<TriggerConditionBuilder value="rainfall >= 50" onChange={onChange} />);
+    const [fieldSelect, operatorSelect] = screen.getAllByRole("combobox");
+
+    expect(fieldSelect).toHaveValue("rainfall");
+    expect(operatorSelect).toHaveValue(">=");
+    expect(screen.getByDisplayValue("50")).toBeInTheDocument();
+    expect(screen.getByText("rainfall >= 50")).toBeInTheDocument();
+  });
 });
 
 describe("premium, validation, transaction and amount input", () => {


### PR DESCRIPTION
## Summary
- Adds controlled string hydration to `TriggerConditionBuilder`, parsing saved condition strings back into visible rules.
- Passes `draft.triggerCondition` into the builder from the create-policy page so restored drafts hydrate the trigger UI.
- Keeps autosave behavior intact while avoiding local rule resets for in-progress edits emitted by the builder.
- Adds coverage for builder hydration and restored draft autosave wiring.

Fixes #327

## Validation
- `npm run test -- src/components/untested-components.test.tsx -t "trigger condition"`
- `npm run test -- src/app/create/create-page-client.test.tsx`
- `npm run lint -- --file src/components/trigger-condition-builder.tsx --file src/app/create/create-page-client.tsx --file src/app/create/create-page-client.test.tsx --file src/components/untested-components.test.tsx`
- `git diff --check`

## Notes
- The targeted lint command exits successfully but reports the existing `react-hooks/exhaustive-deps` warning in `src/app/create/create-page-client.tsx` for `updateDraft`.
- `npm run type-check -- --pretty false` remains blocked by existing repository issues unrelated to this change, including missing `@sentry/nextjs` types, tests without Jest globals, and existing invalid `IconName` usages.