### PR TITLE
Fix failed policy submission recovery

### DIFF
--- a/frontend/src/app/create/create-page-client.test.tsx
+++ b/frontend/src/app/create/create-page-client.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import CreatePolicyPageClient from "./create-page-client";
+import { LanguageProvider } from "@/i18n/provider";
 
 vi.mock("@/components/wallet-provider", () => ({
   useWallet: () => ({
@@ -53,9 +54,46 @@ vi.mock("@/components/oracle-source-selector", () => ({
     ),
 }));
 
+function renderCreatePage() {
+  return render(
+    <LanguageProvider>
+      <CreatePolicyPageClient />
+    </LanguageProvider>,
+  );
+}
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
 describe("CreatePolicyPageClient", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    const storage = createMemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    signTransactionMock.mockReset();
     signTransactionMock.mockResolvedValue({ signedTxXdr: "signed-xdr" });
     window.scrollTo = vi.fn();
   });
@@ -63,17 +101,18 @@ describe("CreatePolicyPageClient", () => {
   afterEach(() => {
     vi.useRealTimers();
     localStorage.clear();
+    cleanup();
   });
 
   it("moves from policy type selection into configure step", () => {
-    render(<CreatePolicyPageClient />);
+    renderCreatePage();
     fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
 
     expect(screen.getByRole("heading", { name: /configure your policy/i })).toBeInTheDocument();
   });
 
   it("applies form validation for invalid coverage values", () => {
-    render(<CreatePolicyPageClient />);
+    renderCreatePage();
     fireEvent.click(screen.getByRole("radio", { name: /weather protection/i }));
 
     const coverageInput = screen.getByLabelText(/coverage amount/i);
@@ -96,7 +135,7 @@ describe("CreatePolicyPageClient", () => {
         oracleProvider: "weatherlink-prime",
       }),
     );
-    render(<CreatePolicyPageClient />);
+    renderCreatePage();
 
     expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
 
@@ -110,6 +149,81 @@ describe("CreatePolicyPageClient", () => {
     });
     act(() => {
       vi.advanceTimersByTime(3500);
+    });
+
+    expect(screen.getByText(/policy created successfully/i)).toBeInTheDocument();
+  });
+
+  it("keeps the draft available after a failed wallet signature", async () => {
+    signTransactionMock.mockRejectedValueOnce(new Error("User declined signature"));
+    localStorage.setItem(
+      "stellarinsure-policy-draft",
+      JSON.stringify({
+        policyType: "weather",
+        coverageAmount: "5000",
+        premium: "120",
+        triggerCondition: "rainfall > 50",
+        duration: "90",
+        oracleProvider: "weatherlink-prime",
+      }),
+    );
+    renderCreatePage();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /sign and submit/i }));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(screen.getByText(/policy submission needs attention/i)).toBeInTheDocument();
+    expect(screen.getByText(/user declined signature/i)).toBeInTheDocument();
+    expect(screen.getByText(/your draft is still saved/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /back to review/i }));
+
+    expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
+    expect(screen.getByText("rainfall > 50")).toBeInTheDocument();
+  });
+
+  it("retries submission after a failed wallet signature", async () => {
+    signTransactionMock
+      .mockRejectedValueOnce(new Error("User declined signature"))
+      .mockResolvedValueOnce({ signedTxXdr: "signed-xdr" });
+    localStorage.setItem(
+      "stellarinsure-policy-draft",
+      JSON.stringify({
+        policyType: "weather",
+        coverageAmount: "5000",
+        premium: "120",
+        triggerCondition: "rainfall > 50",
+        duration: "90",
+        oracleProvider: "weatherlink-prime",
+      }),
+    );
+    renderCreatePage();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /sign and submit/i }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /retry signature/i }));
+    });
+    expect(signTransactionMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      vi.advanceTimersByTime(2500);
     });
 
     expect(screen.getByText(/policy created successfully/i)).toBeInTheDocument();

--- a/frontend/src/app/create/create-page-client.tsx
+++ b/frontend/src/app/create/create-page-client.tsx
@@ -333,6 +333,7 @@ export default function CreatePolicyPageClient() {
   const [oracleProviders, setOracleProviders] = useState<OracleProvider[]>([]);
   const [oracleReloadCounter, setOracleReloadCounter] = useState(0);
   const [receipt, setReceipt] = useState<ReceiptData | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [isEstimating, setIsEstimating] = useState(false);
   const [estimationError, setEstimationError] = useState(false);
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
@@ -421,6 +422,7 @@ export default function CreatePolicyPageClient() {
       return;
     }
 
+    setSubmissionError(null);
     const activeOracle = oracleProviders.find((provider) => provider.id === draft.oracleProvider);
     const coverageForReceipt =
       parsedCoverageAmount !== null ? formatAssetAmount(parsedCoverageAmount) : draft.coverageAmount;
@@ -442,6 +444,8 @@ export default function CreatePolicyPageClient() {
     updatedSteps[0] = { ...updatedSteps[0], status: "active" };
     setTxSteps(updatedSteps);
 
+    let signingProgressTimer: number | undefined;
+
     try {
       // Dummy transaction (in a real app, you'd build a proper Soroban transaction)
       const dummyTx = "AAAAAgAAAAA6V+GyS5x1u+WCzONvDjqnqF6nWCAf3g4pY9qpArIB";
@@ -450,7 +454,7 @@ export default function CreatePolicyPageClient() {
         network: "TESTNET",
       });
 
-      setTimeout(() => {
+      signingProgressTimer = window.setTimeout(() => {
         const next = [...updatedSteps];
         next[0] = { ...next[0], status: "completed" };
         next[1] = { ...next[1], status: "active" };
@@ -458,7 +462,10 @@ export default function CreatePolicyPageClient() {
       }, 1200);
 
       // Await Freighter signature
-      const signedTx = await sigPromise;
+      await sigPromise;
+      if (signingProgressTimer !== undefined) {
+        window.clearTimeout(signingProgressTimer);
+      }
 
       const next = [...updatedSteps];
       next[0] = { ...next[0], status: "completed" };
@@ -474,13 +481,28 @@ export default function CreatePolicyPageClient() {
         clearDraft();
       }, 2000);
     } catch (error) {
+      if (signingProgressTimer !== undefined) {
+        window.clearTimeout(signingProgressTimer);
+      }
       const errorSteps = [...updatedSteps];
       errorSteps[0] = { ...errorSteps[0], status: "failed" };
       setTxSteps(errorSteps);
+      setSubmissionError(
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "Wallet signing failed. Review the policy details or retry the signature request.",
+      );
       logError(error instanceof Error ? error : new Error(String(error)), {
         tags: { component: "CreatePolicyPageClient", action: "simulateSubmit" }
       });
     }
+  }
+
+  function handleReturnToReview() {
+    setSubmissionError(null);
+    setReceipt(null);
+    setTxSteps(DEFAULT_TX_STEPS);
+    setStep(2);
   }
 
   const parsedCoverageAmount = parseAmountInput(draft.coverageAmount);
@@ -786,6 +808,27 @@ export default function CreatePolicyPageClient() {
                 setReceipt(null);
               }}
             />
+          ) : null}
+
+          {submissionError ? (
+            <div className="state-card motion-panel" role="alert" aria-live="assertive">
+              <span className="state-icon" aria-hidden="true">
+                <Icon name="alert-triangle" size="lg" tone="danger" />
+              </span>
+              <h3>Policy submission needs attention</h3>
+              <p className="state-copy">
+                We could not complete the wallet signature, so the policy was not submitted. Your draft is still saved.
+              </p>
+              <p className="form-status">{submissionError}</p>
+              <div className="inline-actions">
+                <button className="cta-primary" type="button" onClick={simulateSubmit} disabled={!isWalletReady}>
+                  Retry signature
+                </button>
+                <button className="cta-secondary" type="button" onClick={handleReturnToReview}>
+                  Back to review
+                </button>
+              </div>
+            </div>
           ) : null}
         </section>
       )}


### PR DESCRIPTION
## Summary
- add a failed-submission recovery panel after wallet signature errors
- preserve the policy draft and let users either retry signature or return to review
- clear stale signature progress timers so failed submissions do not advance the timeline later
- add regression coverage for retry and back-to-review recovery

Closes #330.

## Validation
- npm run test -- src/app/create/create-page-client.test.tsx
- npx eslint src/app/create/create-page-client.tsx src/app/create/create-page-client.test.tsx (passes with existing react-hooks/exhaustive-deps warning in create-page-client.tsx)
- git diff --check