### PR TITLE
fix: backend validation and pagination improvements

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,6 +3,7 @@ import logging
 import time
 import json
 import uuid
+from datetime import datetime
 from sqlalchemy import text
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -177,12 +178,24 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    # Format validation errors in a structured way
+    errors = exc.errors()
+    formatted_errors = []
+    for error in errors:
+        formatted_errors.append({
+            "field": ".".join(str(loc) for loc in error["loc"]),
+            "message": error["msg"],
+            "type": error["type"]
+        })
+    
     return JSONResponse(
         status_code=422,
-        content=ErrorResponse(
-            error_code="VAL_001",
-            detail=str(exc.errors())
-        ).model_dump(mode="json")
+        content={
+            "error_code": "VAL_001",
+            "detail": "Request validation failed",
+            "errors": formatted_errors,
+            "timestamp": datetime.utcnow().isoformat()
+        }
     )
 
 @app.get("/", summary="Root endpoint", description="Returns a simple welcome message.")

--- a/backend/src/routes/claims.py
+++ b/backend/src/routes/claims.py
@@ -256,12 +256,15 @@ async def list_claims(
         for claim in claims
     ]
 
+    total_pages = (total + per_page - 1) // per_page if total > 0 else 0
+
     return {
         "claims": claim_responses,
         "total": total,
         "page": page,
         "per_page": per_page,
-        "has_next": (offset + per_page) < total
+        "has_next": (offset + per_page) < total,
+        "total_pages": total_pages
     }
 
 
@@ -368,10 +371,13 @@ async def list_claims_by_policy(
         for claim in claims
     ]
 
+    total_pages = (total + per_page - 1) // per_page if total > 0 else 0
+
     return {
         "claims": claim_responses,
         "total": total,
         "page": page,
         "per_page": per_page,
-        "has_next": (offset + per_page) < total
+        "has_next": (offset + per_page) < total,
+        "total_pages": total_pages
     }

--- a/backend/src/routes/transactions.py
+++ b/backend/src/routes/transactions.py
@@ -47,6 +47,14 @@ async def get_transactions(
     
     Returns paginated results with policy and claim relationships included.
     """
+    # Validate date range
+    if start_date and end_date and end_date < start_date:
+        from ..errors import ValidationError
+        raise ValidationError(
+            detail="end_date must be greater than or equal to start_date",
+            error_code="VAL_002"
+        )
+    
     # Build query with filters
     query = db.query(Transaction).filter(Transaction.user_id == current_user.id)
     
@@ -88,11 +96,13 @@ async def get_transactions(
     ]
     
     has_next = (offset + per_page) < total
+    total_pages = (total + per_page - 1) // per_page if total > 0 else 0
     
     return {
         "transactions": transaction_responses,
         "total": total,
         "page": page,
         "per_page": per_page,
-        "has_next": has_next
+        "has_next": has_next,
+        "total_pages": total_pages
     }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -130,6 +130,12 @@ def admin_headers(admin_user):
 
 
 @pytest.fixture()
+def authenticated_user(auth_user, auth_headers):
+    """Fixture that returns both user and headers as a tuple"""
+    return auth_user, auth_headers
+
+
+@pytest.fixture()
 def refresh_token(auth_user):
     return create_refresh_token(
         {"sub": str(auth_user.id), "stellar_address": auth_user.stellar_address}

--- a/backend/tests/test_claims.py
+++ b/backend/tests/test_claims.py
@@ -184,3 +184,115 @@ def test_claim_routes_require_authentication(client):
     response = client.get("/claims/")
 
     assert response.status_code in (401, 403)
+
+
+def test_list_claims_includes_total_pages(
+    client, auth_headers, auth_user, policy_factory, claim_factory, db_session
+):
+    """Test that list_claims includes total_pages in response"""
+    policy = policy_factory(auth_user, status=PolicyStatus.claim_pending)
+    
+    # Create 15 claims
+    for i in range(15):
+        claim_factory(auth_user, policy, claim_amount=100.0 + i)
+    
+    # Test with per_page=10
+    response = client.get("/claims/?page=1&per_page=10", headers=auth_headers)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_pages" in data
+    assert data["total_pages"] == 2  # 15 items / 10 per page = 2 pages
+    assert data["total"] == 15
+    assert len(data["claims"]) == 10
+
+
+def test_list_claims_total_pages_non_divisible(
+    client, auth_headers, auth_user, policy_factory, claim_factory, db_session
+):
+    """Test that total_pages rounds up correctly for non-divisible totals"""
+    policy = policy_factory(auth_user, status=PolicyStatus.claim_pending)
+    
+    # Create 23 claims
+    for i in range(23):
+        claim_factory(auth_user, policy, claim_amount=100.0 + i)
+    
+    # Test with per_page=7
+    response = client.get("/claims/?page=1&per_page=7", headers=auth_headers)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 4  # 23 items / 7 per page = 4 pages (rounded up)
+    assert data["total"] == 23
+
+
+def test_list_claims_total_pages_empty_result(
+    client, auth_headers, auth_user, db_session
+):
+    """Test that total_pages is 0 for empty results"""
+    response = client.get("/claims/", headers=auth_headers)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 0
+    assert data["total"] == 0
+
+
+def test_list_claims_by_policy_includes_total_pages(
+    client, auth_headers, auth_user, policy_factory, claim_factory, db_session
+):
+    """Test that list_claims_by_policy includes total_pages in response"""
+    policy = policy_factory(auth_user, status=PolicyStatus.claim_pending)
+    
+    # Create 12 claims
+    for i in range(12):
+        claim_factory(auth_user, policy, claim_amount=100.0 + i)
+    
+    # Test with per_page=5
+    response = client.get(
+        f"/claims/policy/{policy.id}?page=1&per_page=5",
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_pages" in data
+    assert data["total_pages"] == 3  # 12 items / 5 per page = 3 pages (rounded up)
+    assert data["total"] == 12
+    assert len(data["claims"]) == 5
+
+
+def test_list_claims_by_policy_total_pages_empty(
+    client, auth_headers, auth_user, policy_factory, db_session
+):
+    """Test that total_pages is 0 for empty policy claims"""
+    policy = policy_factory(auth_user, status=PolicyStatus.active)
+    
+    response = client.get(f"/claims/policy/{policy.id}", headers=auth_headers)
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 0
+    assert data["total"] == 0
+
+
+def test_list_claims_by_policy_total_pages_exact_division(
+    client, auth_headers, auth_user, policy_factory, claim_factory, db_session
+):
+    """Test total_pages when total divides evenly by per_page"""
+    policy = policy_factory(auth_user, status=PolicyStatus.claim_pending)
+    
+    # Create exactly 20 claims
+    for i in range(20):
+        claim_factory(auth_user, policy, claim_amount=100.0 + i)
+    
+    # Test with per_page=10 (divides evenly)
+    response = client.get(
+        f"/claims/policy/{policy.id}?page=1&per_page=10",
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 2  # 20 items / 10 per page = exactly 2 pages
+    assert data["total"] == 20

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -196,3 +196,149 @@ def test_get_transactions_only_returns_user_own_transactions(client, authenticat
     data = response.json()
     assert data["total"] == 1
     assert data["transactions"][0]["user_id"] == user.id
+
+
+def test_get_transactions_rejects_invalid_date_range(client, authenticated_user, db_session):
+    """Test that reversed date ranges are rejected with 422"""
+    user, headers = authenticated_user
+    
+    now = datetime.utcnow()
+    yesterday = now - timedelta(days=1)
+    
+    # Try to query with end_date before start_date
+    start_date = now.isoformat()
+    end_date = yesterday.isoformat()
+    
+    response = client.get(
+        f"/transactions?start_date={start_date}&end_date={end_date}",
+        headers=headers
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    assert data["error_code"] == "VAL_002"
+    assert "end_date must be greater than or equal to start_date" in data["detail"]
+
+
+def test_get_transactions_accepts_valid_date_ranges(client, authenticated_user, db_session):
+    """Test that valid date ranges work correctly"""
+    user, headers = authenticated_user
+    
+    now = datetime.utcnow()
+    yesterday = now - timedelta(days=1)
+    
+    tx = Transaction(
+        user_id=user.id,
+        transaction_hash="hash1",
+        amount=100.0,
+        transaction_type="premium",
+        status="successful",
+        created_at=now
+    )
+    db_session.add(tx)
+    db_session.commit()
+    
+    # Test with valid range
+    start_date = yesterday.isoformat()
+    end_date = now.isoformat()
+    
+    response = client.get(
+        f"/transactions?start_date={start_date}&end_date={end_date}",
+        headers=headers
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+
+
+def test_get_transactions_accepts_equal_dates(client, authenticated_user, db_session):
+    """Test that equal start and end dates are accepted"""
+    user, headers = authenticated_user
+    
+    now = datetime.utcnow()
+    
+    # Test with equal dates
+    date_str = now.isoformat()
+    
+    response = client.get(
+        f"/transactions?start_date={date_str}&end_date={date_str}",
+        headers=headers
+    )
+    
+    assert response.status_code == 200
+
+
+def test_get_transactions_accepts_one_sided_date_filters(client, authenticated_user, db_session):
+    """Test that one-sided date filters work correctly"""
+    user, headers = authenticated_user
+    
+    now = datetime.utcnow()
+    
+    tx = Transaction(
+        user_id=user.id,
+        transaction_hash="hash1",
+        amount=100.0,
+        transaction_type="premium",
+        status="successful",
+        created_at=now
+    )
+    db_session.add(tx)
+    db_session.commit()
+    
+    # Test with only start_date
+    response = client.get(
+        f"/transactions?start_date={now.isoformat()}",
+        headers=headers
+    )
+    assert response.status_code == 200
+    
+    # Test with only end_date
+    response = client.get(
+        f"/transactions?end_date={now.isoformat()}",
+        headers=headers
+    )
+    assert response.status_code == 200
+
+
+def test_get_transactions_includes_total_pages(client, authenticated_user, db_session):
+    """Test that total_pages is included in response"""
+    user, headers = authenticated_user
+    
+    # Create 25 transactions
+    for i in range(25):
+        tx = Transaction(
+            user_id=user.id,
+            transaction_hash=f"hash{i}",
+            amount=100.0 + i,
+            transaction_type="premium",
+            status="successful"
+        )
+        db_session.add(tx)
+    db_session.commit()
+    
+    # Test with per_page=10
+    response = client.get("/transactions?page=1&per_page=10", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_pages" in data
+    assert data["total_pages"] == 3  # 25 items / 10 per page = 3 pages
+    assert data["total"] == 25
+    
+    # Test with per_page=7 (non-divisible)
+    response = client.get("/transactions?page=1&per_page=7", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 4  # 25 items / 7 per page = 4 pages (rounded up)
+
+
+def test_get_transactions_total_pages_empty_result(client, authenticated_user, db_session):
+    """Test that total_pages is 0 for empty results"""
+    user, headers = authenticated_user
+    
+    response = client.get("/transactions", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_pages"] == 0
+    assert data["total"] == 0
+

--- a/backend/tests/test_validation_errors.py
+++ b/backend/tests/test_validation_errors.py
@@ -1,0 +1,127 @@
+import pytest
+
+
+def test_validation_error_returns_structured_errors(client, auth_headers):
+    """Test that validation errors return structured field errors"""
+    # Send invalid policy creation request (missing required fields)
+    response = client.post(
+        "/policies/",
+        headers=auth_headers,
+        json={
+            "policy_type": "weather",
+            "coverage_amount": -100.0,  # Invalid: negative
+            "premium": 50.0,
+            # Missing start_time, end_time, trigger_condition
+        }
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    
+    # Check error structure
+    assert "error_code" in data
+    assert data["error_code"] == "VAL_001"
+    assert "detail" in data
+    assert "errors" in data
+    assert "timestamp" in data
+    
+    # Check that errors is a list of structured objects
+    assert isinstance(data["errors"], list)
+    assert len(data["errors"]) > 0
+    
+    # Each error should have field, message, and type
+    for error in data["errors"]:
+        assert "field" in error
+        assert "message" in error
+        assert "type" in error
+
+
+def test_validation_error_includes_field_paths(client, auth_headers):
+    """Test that validation errors include proper field paths"""
+    response = client.post(
+        "/policies/",
+        headers=auth_headers,
+        json={
+            "policy_type": "weather",
+            "coverage_amount": "not_a_number",  # Invalid type
+            "premium": 50.0,
+            "start_time": 1000,
+            "end_time": 2000,
+            "trigger_condition": "test"
+        }
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    
+    # Find the coverage_amount error
+    coverage_errors = [e for e in data["errors"] if "coverage_amount" in e["field"]]
+    assert len(coverage_errors) > 0
+    
+    # Check that field path is properly formatted
+    assert coverage_errors[0]["field"] == "body.coverage_amount"
+
+
+def test_validation_error_preserves_error_code(client, auth_headers):
+    """Test that VAL_001 error code is preserved in structured errors"""
+    response = client.post(
+        "/claims/",
+        headers=auth_headers,
+        json={
+            "policy_id": "not_an_int",  # Invalid type
+            "claim_amount": 100.0,
+            "proof": "test"
+        }
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    assert data["error_code"] == "VAL_001"
+
+
+def test_validation_error_multiple_fields(client, auth_headers):
+    """Test that multiple field errors are all returned"""
+    response = client.post(
+        "/policies/",
+        headers=auth_headers,
+        json={
+            "policy_type": "invalid_type",
+            "coverage_amount": -100.0,
+            "premium": -50.0,
+            "start_time": -1,
+            "end_time": -2,
+            "trigger_condition": ""
+        }
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    
+    # Should have multiple errors
+    assert len(data["errors"]) >= 3
+    
+    # Check that different fields are reported
+    fields = [e["field"] for e in data["errors"]]
+    assert any("coverage_amount" in f for f in fields)
+    assert any("premium" in f for f in fields)
+
+
+def test_validation_error_empty_required_field(client, auth_headers):
+    """Test validation error for empty required fields"""
+    response = client.post(
+        "/claims/",
+        headers=auth_headers,
+        json={
+            "policy_id": 1,
+            "claim_amount": 100.0,
+            "proof": ""  # Empty proof
+        }
+    )
+    
+    assert response.status_code == 422
+    data = response.json()
+    assert data["error_code"] == "VAL_001"
+    
+    # Find proof error
+    proof_errors = [e for e in data["errors"] if "proof" in e["field"]]
+    assert len(proof_errors) > 0


### PR DESCRIPTION
# Backend Validation and Pagination Improvements

## Overview
This PR addresses four backend issues related to validation and pagination improvements in the StellarInsure API.

## Issues Addressed

### Closes #358 - Backend: Validate transaction date range filters
**Problem:** In `backend/src/routes/transactions.py`, `start_date` and `end_date` parameters could be reversed silently, leading to confusing empty results.

**Solution:**
- Added validation to reject requests where `end_date < start_date`
- Returns a clear 422 error with error code `VAL_002` and descriptive message
- One-sided date filters (only start or only end) continue to work
- Equal dates are accepted (start_date == end_date)

**Tests Added:**
- `test_get_transactions_rejects_invalid_date_range` - Verifies 422 response for reversed dates
- `test_get_transactions_accepts_valid_date_ranges` - Confirms valid ranges work
- `test_get_transactions_accepts_equal_dates` - Tests equal date handling
- `test_get_transactions_accepts_one_sided_date_filters` - Validates single-sided filters

---

### Closes #355 - Backend: Return structured field errors for request validation failures
**Problem:** In `backend/src/main.py`, `RequestValidationError` was converted to a stringified list in the `detail` field, making it difficult for clients to parse validation errors programmatically.

**Solution:**
- Modified the validation exception handler to return structured error details
- Each validation error now includes:
  - `field`: The field path (e.g., "body.coverage_amount")
  - `message`: Human-readable error message
  - `type`: Error type from Pydantic
- Preserved the existing `error_code: VAL_001` for backward compatibility
- Added `timestamp` field for error tracking

**Response Format:**
```json
{
  "error_code": "VAL_001",
  "detail": "Request validation failed",
  "errors": [
    {
      "field": "body.coverage_amount",
      "message": "Input should be a valid number",
      "type": "float_parsing"
    }
  ],
  "timestamp": "2026-05-29T10:30:00.000000"
}
```

**Tests Added:**
- `test_validation_error_returns_structured_errors` - Verifies structured error format
- `test_validation_error_includes_field_paths` - Checks field path formatting
- `test_validation_error_preserves_error_code` - Confirms VAL_001 is preserved
- `test_validation_error_multiple_fields` - Tests multiple field errors
- `test_validation_error_empty_required_field` - Validates empty field handling

---

### Closes #361 - Backend: Add total pages to paginated transaction responses
**Problem:** In `backend/src/routes/transactions.py`, responses included `total`, `page`, `per_page`, and `has_next`, but not `total_pages`, making it difficult for clients to build pagination UI.

**Solution:**
- Added `total_pages` field to transaction list response
- Calculation: `(total + per_page - 1) // per_page` (rounds up)
- Returns `0` for empty result sets
- All existing fields preserved for backward compatibility

**Tests Added:**
- `test_get_transactions_includes_total_pages` - Verifies total_pages calculation
- `test_get_transactions_total_pages_empty_result` - Tests empty result handling

---

### Closes #362 - Backend: Add total pages to claims list responses
**Problem:** In `backend/src/routes/claims.py`, claim list endpoints (`/claims/` and `/claims/policy/{policy_id}`) returned pagination metadata without `total_pages`.

**Solution:**
- Added `total_pages` to both claim list endpoints:
  - `GET /claims/` - List user claims
  - `GET /claims/policy/{policy_id}` - List claims by policy
- Same calculation logic as transactions
- Handles empty results and non-divisible totals correctly

**Tests Added:**
- `test_list_claims_includes_total_pages` - Verifies total_pages in /claims/
- `test_list_claims_total_pages_non_divisible` - Tests rounding up
- `test_list_claims_total_pages_empty_result` - Tests empty results
- `test_list_claims_by_policy_includes_total_pages` - Verifies total_pages in /claims/policy/{id}
- `test_list_claims_by_policy_total_pages_empty` - Tests empty policy claims
- `test_list_claims_by_policy_total_pages_exact_division` - Tests exact division

---

## Testing
All changes include comprehensive test coverage:
- **Date validation:** 4 new tests in `test_transactions.py`
- **Structured errors:** 5 new tests in `test_validation_errors.py`
- **Transaction pagination:** 2 new tests in `test_transactions.py`
- **Claims pagination:** 6 new tests in `test_claims.py`

Total: **17 new tests** covering all acceptance criteria.

## Backward Compatibility
- All existing response fields are preserved
- New fields are additive only
- Error code `VAL_001` is maintained
- Existing clients will continue to work without changes

## API Changes

### Modified Endpoints

#### `GET /transactions`
**Added Response Field:**
```json
{
  "total_pages": 3
}
```

#### `GET /claims/`
**Added Response Field:**
```json
{
  "total_pages": 2
}
```

#### `GET /claims/policy/{policy_id}`
**Added Response Field:**
```json
{
  "total_pages": 1
}
```

#### Validation Errors (422 responses)
**New Structure:**
```json
{
  "error_code": "VAL_001",
  "detail": "Request validation failed",
  "errors": [
    {
      "field": "body.field_name",
      "message": "Error message",
      "type": "error_type"
    }
  ],
  "timestamp": "2026-05-29T10:30:00.000000"
}
```

## Files Changed
- `backend/src/routes/transactions.py` - Date validation + total_pages
- `backend/src/routes/claims.py` - total_pages for both endpoints
- `backend/src/main.py` - Structured validation errors
- `backend/tests/test_transactions.py` - 6 new tests
- `backend/tests/test_claims.py` - 6 new tests
- `backend/tests/test_validation_errors.py` - 5 new tests (new file)
- `backend/tests/conftest.py` - Added authenticated_user fixture

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] New tests added for all changes
- [x] Backward compatibility maintained
- [x] Error codes preserved
- [x] Documentation updated (PR description)
- [x] No breaking changes
