### PR TITLE
Policy terminal guard, total_pages pagination, webhook delivery pagination, proof length validation

### DIFF
--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -47,6 +47,10 @@ class InsufficientCoverageError(StellarInsureError):
     def __init__(self, detail: str = "Claim amount exceeds remaining coverage"):
         super().__init__(status.HTTP_400_BAD_REQUEST, detail, "POLICY_003")
 
+class PolicyAlreadyTerminalError(StellarInsureError):
+    def __init__(self, detail: str = "Policy is already in a terminal state"):
+        super().__init__(status.HTTP_400_BAD_REQUEST, detail, "POLICY_004")
+
 # Claim Errors (CLAIM_xxx)
 class ClaimNotFoundError(StellarInsureError):
     def __init__(self, detail: str = "Claim not found"):

--- a/backend/src/routes/policies.py
+++ b/backend/src/routes/policies.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from fastapi import APIRouter, Depends, HTTPException, status, Query, BackgroundTasks
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -17,7 +18,8 @@ from ..dependencies import get_current_active_user
 from ..errors import (
     PolicyNotFoundError,
     InvalidPolicyTimeRangeError,
-    PolicyNotEligibleForClaimError
+    PolicyNotEligibleForClaimError,
+    PolicyAlreadyTerminalError
 )
 from ..cache import cache_get, cache_set, invalidate_policy_cache
 from ..services.webhook_service import dispatch_webhook_event
@@ -129,7 +131,8 @@ async def get_user_policies(
         query = query.filter(Policy.policy_type == policy_type)
     
     total = query.count()
-    
+    total_pages = math.ceil(total / per_page) if per_page > 0 else 0
+
     offset = (page - 1) * per_page
     policies = query.order_by(Policy.created_at.desc()).offset(offset).limit(per_page).all()
     
@@ -156,7 +159,8 @@ async def get_user_policies(
         total=total,
         page=page,
         per_page=per_page,
-        has_next=(offset + per_page) < total
+        has_next=(offset + per_page) < total,
+        total_pages=total_pages
     )
     
     cache_set(cache_key, result.model_dump(mode="json"))
@@ -228,7 +232,11 @@ async def cancel_policy(
     
     if policy is None:
         raise PolicyNotFoundError()
-    
+
+    TERMINAL_STATUSES = {PolicyStatus.cancelled, PolicyStatus.expired, PolicyStatus.claim_approved, PolicyStatus.claim_rejected}
+    if policy.status in TERMINAL_STATUSES:
+        raise PolicyAlreadyTerminalError()
+
     policy.status = PolicyStatus.cancelled
     db.commit()
     

--- a/backend/src/routes/webhooks.py
+++ b/backend/src/routes/webhooks.py
@@ -1,4 +1,5 @@
 """Webhook management endpoints for StellarInsure API."""
+import math
 import secrets
 from typing import List
 
@@ -14,6 +15,7 @@ from ..schemas import (
     WebhookUpdateRequest,
     WebhookResponse,
     WebhookDeliveryResponse,
+    WebhookDeliveryListResponse,
     MessageResponse,
 )
 
@@ -183,7 +185,7 @@ async def delete_webhook(
 
 @router.get(
     "/{webhook_id}/deliveries",
-    response_model=List[WebhookDeliveryResponse],
+    response_model=WebhookDeliveryListResponse,
     summary="List webhook deliveries",
     description="Returns the delivery history for a specific webhook, ordered by most recent first.",
     responses={
@@ -207,6 +209,13 @@ async def list_webhook_deliveries(
     if webhook is None:
         raise WebhookNotFoundError()
 
+    total = (
+        db.query(WebhookDelivery)
+        .filter(WebhookDelivery.webhook_id == webhook_id)
+        .count()
+    )
+    total_pages = math.ceil(total / per_page) if per_page > 0 else 0
+
     offset = (page - 1) * per_page
     deliveries = (
         db.query(WebhookDelivery)
@@ -217,15 +226,22 @@ async def list_webhook_deliveries(
         .all()
     )
 
-    return [
-        WebhookDeliveryResponse(
-            id=d.id,
-            webhook_id=d.webhook_id,
-            event_type=d.event_type,
-            response_status=d.response_status,
-            success=d.success,
-            attempts=d.attempts,
-            created_at=d.created_at,
-        )
-        for d in deliveries
-    ]
+    return WebhookDeliveryListResponse(
+        deliveries=[
+            WebhookDeliveryResponse(
+                id=d.id,
+                webhook_id=d.webhook_id,
+                event_type=d.event_type,
+                response_status=d.response_status,
+                success=d.success,
+                attempts=d.attempts,
+                created_at=d.created_at,
+            )
+            for d in deliveries
+        ],
+        total=total,
+        page=page,
+        per_page=per_page,
+        has_next=(offset + per_page) < total,
+        total_pages=total_pages,
+    )

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -190,6 +190,7 @@ class PolicyListResponse(BaseModel):
     page: int = Field(..., description="Current page number", example=1)
     per_page: int = Field(..., description="Number of items per page", example=10)
     has_next: bool = Field(..., description="Whether there are more pages available", example=True)
+    total_pages: int = Field(..., description="Total number of pages", example=10)
 
 
 class PolicyResponse(BaseModel):
@@ -369,3 +370,12 @@ class WebhookDeliveryResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class WebhookDeliveryListResponse(BaseModel):
+    deliveries: List[WebhookDeliveryResponse] = Field(..., description="List of webhook deliveries")
+    total: int = Field(..., description="Total number of deliveries", example=100)
+    page: int = Field(..., description="Current page number", example=1)
+    per_page: int = Field(..., description="Number of items per page", example=20)
+    has_next: bool = Field(..., description="Whether there are more pages available", example=True)
+    total_pages: int = Field(..., description="Total number of pages", example=5)

--- a/smartcontract/src/error.rs
+++ b/smartcontract/src/error.rs
@@ -44,4 +44,5 @@ pub enum Error {
     // Issue #198 — oracle integration
     OracleNotRegistered = 31,
     OracleConditionNotMet = 32,
+    ProofTooLong = 33,
 }

--- a/smartcontract/src/lib.rs
+++ b/smartcontract/src/lib.rs
@@ -268,6 +268,11 @@ impl StellarInsure {
             return Err(Error::InvalidClaimAmount);
         }
 
+        const MAX_PROOF_LEN: u32 = 256;
+        if proof.len() > MAX_PROOF_LEN {
+            return Err(Error::ProofTooLong);
+        }
+
         if env.ledger().timestamp() > policy.end_time {
             expire_policy_if_needed(&env, &mut policy, policy_id);
             return Err(Error::PolicyExpired);


### PR DESCRIPTION
## Summary

- Prevents cancelling policies that are already in a terminal state (expired, claim_approved, claim_rejected, or already cancelled) with a 400 error (fixes #364)
- Adds `total_pages` field to `PolicyListResponse` so clients can render full pagination controls (fixes #363)
- Wraps webhook delivery list in a paginated `WebhookDeliveryListResponse` schema with `total`, `page`, `per_page`, `has_next`, and `total_pages` fields (fixes #371)
- Adds `ProofTooLong` error and a 256-character proof length guard in the `submit_claim` contract function (fixes #380)

## Test plan

- [ ] `DELETE /policies/{id}` on a cancelled/expired/approved/rejected policy returns 400 "Policy is already in a terminal state"
- [ ] `GET /policies/` returns `total_pages` field in the response body
- [ ] `GET /webhooks/{id}/deliveries` returns paginated wrapper with `total`, `page`, `per_page`, `has_next`, `total_pages`
- [ ] Contract `submit_claim` with proof longer than 256 chars returns `ProofTooLong` error

Closes #363
Closes #364
Closes #371
Closes #380