### PR TITLE
feat: unread badge, coverage range guard, /create CTA, responsive skeleton

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2897,6 +2897,33 @@ dt,
   background: rgba(255, 255, 255, 0.12);
 }
 
+/* Unread-count badge on the notifications bell trigger (#302). */
+.topbar-action-btn--with-badge {
+  position: relative;
+}
+
+.topbar-action-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 1.1rem;
+  height: 1.1rem;
+  padding: 0 0.32rem;
+  border-radius: 999px;
+  background: var(--accent, #d92d20);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.1rem;
+  text-align: center;
+  pointer-events: none;
+  box-shadow: 0 0 0 2px var(--card-bg, #fff);
+}
+
+[data-theme='dark'] .topbar-action-badge {
+  box-shadow: 0 0 0 2px var(--card-bg, #0b0d12);
+}
+
 /* Notifications panel */
 
 .notifications-panel-overlay {
@@ -5365,4 +5392,141 @@ dt,
   border: none;
   box-shadow: none;
   padding-inline: 0;
+}
+
+/* ── Policy detail loading skeleton (#339) ──────────────────────────────────
+   Replaces the bag of inline styles that previously hardcoded
+   `gridTemplateColumns: "1fr 1fr"` (which overflowed at 375px viewports). */
+
+.policy-skeleton__header {
+  margin-bottom: 2rem;
+}
+
+.policy-skeleton__header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.policy-skeleton__header-text {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.policy-skeleton__header-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.policy-skeleton__line {
+  display: block;
+}
+.policy-skeleton__line--label {
+  width: 80px;
+  height: 12px;
+  margin-bottom: 0.75rem;
+}
+.policy-skeleton__line--title {
+  width: 55%;
+  height: 32px;
+  margin-bottom: 0.5rem;
+}
+.policy-skeleton__line--meta {
+  width: 30%;
+  height: 14px;
+}
+.policy-skeleton__line--value {
+  width: 80%;
+  height: 20px;
+}
+.policy-skeleton__line--panel-title {
+  width: 40%;
+  height: 14px;
+  margin-bottom: 1rem;
+}
+.policy-skeleton__line--row-title {
+  width: 50%;
+  height: 12px;
+  margin-bottom: 0.4rem;
+}
+.policy-skeleton__line--row-meta {
+  width: 30%;
+  height: 10px;
+}
+
+.policy-skeleton__button {
+  width: 110px;
+  height: 38px;
+  border-radius: 8px;
+}
+
+.policy-skeleton__metrics {
+  margin-bottom: 2rem;
+}
+.policy-skeleton__metric {
+  padding: 1.25rem;
+}
+.policy-skeleton__metric-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  margin-bottom: 0.75rem;
+}
+
+.policy-skeleton__panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+/* Collapse to a single column on narrow viewports so the skeleton
+   doesn't overflow at 375px (#339 AC). */
+@media (max-width: 640px) {
+  .policy-skeleton__panels {
+    grid-template-columns: 1fr;
+  }
+  .policy-skeleton__line--title {
+    width: 70%;
+  }
+}
+
+.policy-skeleton__panel {
+  padding: 1.5rem;
+}
+
+.policy-skeleton__row {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.policy-skeleton__row-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.policy-skeleton__row-text {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.policy-skeleton__row-status {
+  width: 70px;
+  height: 24px;
+  border-radius: 20px;
+}
+
+/* Coverage-range filter warning (#308). */
+.policies-filters__warning {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--accent, #d92d20);
+  min-height: 1.2em; /* reserve space so the layout doesn't shift */
+}
+.policies-filters__warning:empty {
+  visibility: hidden;
 }

--- a/frontend/src/app/home-page-client.tsx
+++ b/frontend/src/app/home-page-client.tsx
@@ -33,10 +33,24 @@ export default function HomePage() {
             <p className="hero-description">{t("hero.description")}</p>
 
             <div className="cta-row hero-cta">
-              <a className="cta-primary cta-primary--large" href="#coverage" data-onboarding="hero-primary-cta" rel="noopener noreferrer">
+              {/* #318 — Primary CTA now routes to `/create` (the product's
+                  actual creation workflow) instead of jumping to the
+                  on-page #coverage anchor. The secondary CTA remains
+                  in-page so visitors can still learn how it works. */}
+              <Link
+                className="cta-primary cta-primary--large"
+                href="/create"
+                data-onboarding="hero-primary-cta"
+                aria-label="Start creating a new insurance policy"
+              >
                 {t("hero.primaryCta")}
-              </a>
-              <a className="cta-secondary cta-secondary--large" href="#workflow" rel="noopener noreferrer">
+              </Link>
+              <a
+                className="cta-secondary cta-secondary--large"
+                href="#workflow"
+                rel="noopener noreferrer"
+                aria-label="Learn how the protocol works"
+              >
                 {t("hero.secondaryCta")}
               </a>
             </div>

--- a/frontend/src/app/policies/[policyId]/policy-detail-page-client.tsx
+++ b/frontend/src/app/policies/[policyId]/policy-detail-page-client.tsx
@@ -269,57 +269,63 @@ export default function PolicyDetailPage({
   }
 
   if (isLoading) {
+    /* #339 — Skeleton layout moved into CSS classes
+       (`.policy-skeleton__*` in globals.css). Inline styles on each
+       Skeleton previously hardcoded `gridTemplateColumns: "1fr 1fr"`
+       so the panel block overflowed at 375px-wide viewports. The
+       class-based layout collapses to a single column at narrow
+       widths and keeps the existing two-column structure on desktop. */
     return (
       <main id="main-content" tabIndex={-1} className="policy-page" aria-busy="true">
         <span className="visually-hidden">Loading policy data, please wait.</span>
-        <section className="policy-shell">
+        <section className="policy-shell policy-skeleton">
           {/* Header */}
-          <div className="policy-header" style={{ marginBottom: "2rem" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1rem", flexWrap: "wrap" }}>
-              <div style={{ flex: 1 }}>
-                <Skeleton style={{ width: "80px", height: "12px", marginBottom: "0.75rem" }} />
-                <Skeleton style={{ width: "55%", height: "32px", marginBottom: "0.5rem" }} />
-                <Skeleton style={{ width: "30%", height: "14px" }} />
+          <div className="policy-header policy-skeleton__header">
+            <div className="policy-skeleton__header-row">
+              <div className="policy-skeleton__header-text">
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--label" />
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--title" />
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--meta" />
               </div>
-              <div style={{ display: "flex", gap: "0.75rem" }}>
-                <Skeleton style={{ width: "110px", height: "38px", borderRadius: "8px" }} />
-                <Skeleton style={{ width: "110px", height: "38px", borderRadius: "8px" }} />
+              <div className="policy-skeleton__header-actions">
+                <Skeleton className="policy-skeleton__button" />
+                <Skeleton className="policy-skeleton__button" />
               </div>
             </div>
           </div>
 
           {/* Key Metrics Grid */}
-          <div className="policy-grid" style={{ marginBottom: "2rem" }}>
+          <div className="policy-grid policy-skeleton__metrics">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={`metric-sk-${i}`} className="hero-card" style={{ padding: "1.25rem" }}>
-                <Skeleton style={{ width: "28px", height: "28px", borderRadius: "50%", marginBottom: "0.75rem" }} />
-                <Skeleton style={{ width: "60%", height: "11px", marginBottom: "0.5rem" }} />
-                <Skeleton style={{ width: "80%", height: "20px" }} />
+              <div key={`metric-sk-${i}`} className="hero-card policy-skeleton__metric">
+                <Skeleton className="policy-skeleton__metric-icon" />
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--label" />
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--value" />
               </div>
             ))}
           </div>
 
-          {/* Two-column panel area */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem", marginBottom: "2rem" }}>
+          {/* Two-column panel area (collapses to one column < 640px) */}
+          <div className="policy-skeleton__panels">
             {Array.from({ length: 2 }).map((_, j) => (
-              <div key={`panel-sk-${j}`} className="panel" style={{ padding: "1.5rem" }}>
-                <Skeleton style={{ width: "40%", height: "14px", marginBottom: "1rem" }} />
+              <div key={`panel-sk-${j}`} className="panel policy-skeleton__panel">
+                <Skeleton className="policy-skeleton__line policy-skeleton__line--panel-title" />
                 <SkeletonText lines={4} />
               </div>
             ))}
           </div>
 
           {/* Timeline / claim list rows */}
-          <div className="panel" style={{ padding: "1.5rem" }}>
-            <Skeleton style={{ width: "35%", height: "14px", marginBottom: "1.25rem" }} />
+          <div className="panel policy-skeleton__panel">
+            <Skeleton className="policy-skeleton__line policy-skeleton__line--panel-title" />
             {Array.from({ length: 3 }).map((_, k) => (
-              <div key={`row-sk-${k}`} style={{ display: "flex", gap: "1rem", alignItems: "center", marginBottom: "1rem" }}>
-                <Skeleton style={{ width: "36px", height: "36px", borderRadius: "50%", flexShrink: 0 }} />
-                <div style={{ flex: 1 }}>
-                  <Skeleton style={{ width: "50%", height: "12px", marginBottom: "0.4rem" }} />
-                  <Skeleton style={{ width: "30%", height: "10px" }} />
+              <div key={`row-sk-${k}`} className="policy-skeleton__row">
+                <Skeleton className="policy-skeleton__row-avatar" />
+                <div className="policy-skeleton__row-text">
+                  <Skeleton className="policy-skeleton__line policy-skeleton__line--row-title" />
+                  <Skeleton className="policy-skeleton__line policy-skeleton__line--row-meta" />
                 </div>
-                <Skeleton style={{ width: "70px", height: "24px", borderRadius: "20px" }} />
+                <Skeleton className="policy-skeleton__row-status" />
               </div>
             ))}
           </div>

--- a/frontend/src/app/policies/policies-list-page-client.tsx
+++ b/frontend/src/app/policies/policies-list-page-client.tsx
@@ -312,9 +312,14 @@ export default function PoliciesListPageClient() {
         const matchesSearch =
           policy.title.toLowerCase().includes(deferredSearch.toLowerCase()) ||
           policy.oracleSource.toLowerCase().includes(deferredSearch.toLowerCase());
+        // #308 — Normalise reversed min/max so a user-typed `min > max`
+        // doesn't silently collapse results to zero. The inline warning
+        // beside the filters explains the swap to the user.
+        const effectiveMin = Math.min(minCoverage, maxCoverage);
+        const effectiveMax = Math.max(minCoverage, maxCoverage);
         const matchesCoverage =
-          policy.coverageAmount >= minCoverage &&
-          policy.coverageAmount <= maxCoverage;
+          policy.coverageAmount >= effectiveMin &&
+          policy.coverageAmount <= effectiveMax;
         const matchesDate =
           (!startDate || policy.createdAt >= startDate) &&
           (!endDate || policy.createdAt <= endDate);
@@ -496,6 +501,51 @@ export default function PoliciesListPageClient() {
             <option value="coverage">Coverage</option>
           </select>
         </label>
+
+        {/* #308 — Coverage min/max filters with reversed-range guard.
+            Invalid combinations are explained inline, announced via the
+            live region below, and *not* silently applied (the effective
+            range is swapped so results don't collapse to zero). */}
+        <label>
+          Min coverage
+          <input
+            type="number"
+            min={0}
+            value={minCoverage}
+            onChange={(event) =>
+              handleFilterChange(() =>
+                setMinCoverage(Number(event.target.value) || 0),
+              )
+            }
+            aria-invalid={minCoverage > maxCoverage}
+            aria-describedby="coverage-range-warning"
+          />
+        </label>
+        <label>
+          Max coverage
+          <input
+            type="number"
+            min={0}
+            value={maxCoverage}
+            onChange={(event) =>
+              handleFilterChange(() =>
+                setMaxCoverage(Number(event.target.value) || 0),
+              )
+            }
+            aria-invalid={minCoverage > maxCoverage}
+            aria-describedby="coverage-range-warning"
+          />
+        </label>
+        <p
+          id="coverage-range-warning"
+          className="policies-filters__warning"
+          role="status"
+          aria-live="polite"
+        >
+          {minCoverage > maxCoverage
+            ? `Minimum coverage (${minCoverage.toLocaleString()}) is greater than maximum (${maxCoverage.toLocaleString()}). Values were swapped automatically; results show the full range you intended.`
+            : ''}
+        </p>
 
         <div className="view-toggle" role="group" aria-label="View mode">
           <button

--- a/frontend/src/components/notifications-panel.tsx
+++ b/frontend/src/components/notifications-panel.tsx
@@ -9,15 +9,13 @@ import React, {
   type RefObject,
 } from 'react';
 import { Icon, type IconName } from '@/components/icon';
+import {
+  MOCK_NOTIFICATIONS,
+  useNotifications,
+  type Notification,
+} from '@/lib/notifications-store';
 
-export interface Notification {
-  id: string;
-  type: 'policy' | 'claim' | 'transaction';
-  title: string;
-  message: string;
-  timestamp: Date;
-  read: boolean;
-}
+export type { Notification };
 
 interface NotificationsPanelProps {
   isOpen: boolean;
@@ -25,32 +23,9 @@ interface NotificationsPanelProps {
   returnFocusRef?: RefObject<HTMLElement>;
 }
 
-const MOCK_NOTIFICATIONS: Notification[] = [
-  {
-    id: '1',
-    type: 'policy',
-    title: 'Policy Updated',
-    message: 'Your weather protection policy has been activated.',
-    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
-    read: false,
-  },
-  {
-    id: '2',
-    type: 'claim',
-    title: 'Claim Approved',
-    message: 'Your claim POL-2024-00124 has been approved for payment.',
-    timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
-    read: false,
-  },
-  {
-    id: '3',
-    type: 'transaction',
-    title: 'Premium Paid',
-    message: 'Your premium payment of 1000 XLM has been confirmed.',
-    timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
-    read: true,
-  },
-];
+// MOCK_NOTIFICATIONS now lives in @/lib/notifications-store so the bell
+// trigger in `site-header.tsx` can subscribe to the same source of truth
+// (#302).
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -88,8 +63,9 @@ export function NotificationsPanel({
   onClose,
   returnFocusRef,
 }: NotificationsPanelProps) {
-  const [notifications, setNotifications] =
-    useState<Notification[]>(MOCK_NOTIFICATIONS);
+  // #302 — Read from the shared store so the bell's unread badge in
+  // site-header sees the same source of truth this panel mutates.
+  const { notifications, setNotifications } = useNotifications();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/site-header.tsx
+++ b/frontend/src/components/site-header.tsx
@@ -17,6 +17,7 @@ import { WalletConnectionButton } from '@/components/wallet-connection-button';
 import { CommandPalette } from '@/components/command-palette';
 import { KeyboardShortcutsHelp } from '@/components/keyboard-shortcuts-help';
 import { NotificationsPanel } from '@/components/notifications-panel';
+import { useNotifications } from '@/lib/notifications-store';
 import { Icon } from '@/components/icon';
 import { ThemeToggle } from '@/components/theme-toggle';
 
@@ -99,6 +100,9 @@ export function SiteHeader() {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const drawerRef = useRef<HTMLElement>(null);
   const notificationsTriggerRef = useRef<HTMLButtonElement>(null);
+  // #302 — Subscribed to the shared notifications store so the bell's
+  // unread indicator stays in sync with the panel without prop drilling.
+  const { unreadCount } = useNotifications();
 
   const closeDrawer = useCallback(() => {
     setDrawerOpen(false);
@@ -225,12 +229,25 @@ export function SiteHeader() {
         <div className="topbar-actions topbar-actions--desktop">
           <button
             ref={notificationsTriggerRef}
-            className="topbar-action-btn"
+            className="topbar-action-btn topbar-action-btn--with-badge"
             onClick={() => setNotificationsOpen(true)}
-            aria-label="Open notifications"
+            aria-label={
+              unreadCount > 0
+                ? `Open notifications, ${unreadCount} unread`
+                : 'Open notifications'
+            }
             title="Notifications"
           >
             <Icon name="bell" size="md" tone="muted" />
+            {unreadCount > 0 && (
+              <span
+                className="topbar-action-badge"
+                aria-hidden="true"
+                data-testid="notifications-unread-badge"
+              >
+                {unreadCount > 9 ? '9+' : unreadCount}
+              </span>
+            )}
           </button>
           <CommandPalette />
           <KeyboardShortcutsHelp />

--- a/frontend/src/lib/notifications-store.ts
+++ b/frontend/src/lib/notifications-store.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared notifications state (#302).
+ *
+ * Both `site-header.tsx` (the bell trigger) and `notifications-panel.tsx`
+ * need to read the same list so the bell's unread indicator stays in
+ * sync with the panel's contents. This module centralises the seed data
+ * + the in-memory subscription so re-render fan-out is a single hook
+ * call away. When a real notifications API arrives, swap the
+ * `MOCK_NOTIFICATIONS` array out for a fetched value — the public hook
+ * surface stays the same.
+ */
+import { useEffect, useState } from 'react';
+
+export interface Notification {
+  id: string;
+  type: 'policy' | 'claim' | 'transaction' | 'system';
+  title: string;
+  message: string;
+  timestamp: Date;
+  read: boolean;
+}
+
+export const MOCK_NOTIFICATIONS: Notification[] = [
+  {
+    id: '1',
+    type: 'policy',
+    title: 'Policy Updated',
+    message: 'Your weather protection policy has been activated.',
+    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    read: false,
+  },
+  {
+    id: '2',
+    type: 'claim',
+    title: 'Claim Approved',
+    message: 'Your claim POL-2024-00124 has been approved for payment.',
+    timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    read: false,
+  },
+  {
+    id: '3',
+    type: 'transaction',
+    title: 'Premium Paid',
+    message: 'Your premium payment of 1000 XLM has been confirmed.',
+    timestamp: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+    read: true,
+  },
+];
+
+type Listener = (notifications: Notification[]) => void;
+
+let currentNotifications: Notification[] = MOCK_NOTIFICATIONS;
+const listeners = new Set<Listener>();
+
+function publish(): void {
+  for (const fn of listeners) fn(currentNotifications);
+}
+
+/**
+ * Replace the entire notifications list. Used by `NotificationsPanel`
+ * when the user marks items as read / clears all / refreshes.
+ */
+export function setNotifications(next: Notification[]): void {
+  currentNotifications = next;
+  publish();
+}
+
+export function getNotifications(): Notification[] {
+  return currentNotifications;
+}
+
+export function getUnreadCount(): number {
+  return currentNotifications.filter((n) => !n.read).length;
+}
+
+/**
+ * React hook returning the current notifications + unread count. Re-renders
+ * the caller whenever `setNotifications` fires.
+ */
+export function useNotifications(): {
+  notifications: Notification[];
+  unreadCount: number;
+  setNotifications: (next: Notification[]) => void;
+} {
+  const [snapshot, setSnapshot] = useState<Notification[]>(currentNotifications);
+
+  useEffect(() => {
+    const handler: Listener = (next) => setSnapshot(next);
+    listeners.add(handler);
+    return () => {
+      listeners.delete(handler);
+    };
+  }, []);
+
+  return {
+    notifications: snapshot,
+    unreadCount: snapshot.filter((n) => !n.read).length,
+    setNotifications,
+  };
+}


### PR DESCRIPTION
## Summary

Four assigned StellarInsure frontend issues, one PR per repo per persona.

- closes #302 — shared notifications store at `frontend/src/lib/notifications-store.ts` lifts `MOCK_NOTIFICATIONS` + a listener registry out of `NotificationsPanel`. `site-header.tsx`'s bell now subscribes via `useNotifications()`, renders a count badge (9+ caps the label), and its `aria-label` includes the unread count. The badge disappears as soon as the panel marks items as read.
- closes #318 — homepage primary CTA is now a `next/link` to `/create` (the actual creation workflow) instead of an in-page `#coverage` anchor. The secondary CTA still routes to `#workflow` for exploration. Both gain explicit `aria-label`s.
- closes #308 — coverage min/max filter inputs are now wired in `policies-list-page-client.tsx`. When `min > max`, an inline `role="status"` / `aria-live="polite"` warning explains the swap. The filter normalises to `Math.min` / `Math.max` so results never collapse silently because of a reversed range. `aria-invalid` is set on both inputs.
- closes #339 — `policy-detail-page-client.tsx` loading skeleton's inline styles (including the `gridTemplateColumns: "1fr 1fr"` block that overflowed at 375px) move to `.policy-skeleton__*` classes in `globals.css`. The panels grid collapses to a single column at `<=640px`.

## Notes

- I could not run `pnpm dev` / `vitest` / Lighthouse locally in the build sandbox; CI is the source of truth.
- The store keeps the same `MOCK_NOTIFICATIONS` seed and `setNotifications(next)` API, so swapping to a real fetch is a single-file change.
- Coverage normalisation is intentionally silent at the filter level (so the result set still makes sense), but the warning panel tells the user what happened.

## Test plan

- [ ] Manual: open the app — bell shows the unread count from the mock store; open the panel and the badge updates as items are marked read.
- [ ] Manual: visit `/policies`, enter min > max coverage — warning appears, results don't collapse.
- [ ] Manual: homepage primary CTA goes to `/create`.
- [ ] Manual: open `/policies/<id>` while loading at 375px — skeleton fits, no horizontal scroll.