### PR TITLE
fix: enforce production secret validation and transaction filter constraints

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -2,7 +2,7 @@ import os
 import logging
 from typing import List, Optional
 from pydantic_settings import BaseSettings
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from functools import lru_cache
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,15 @@ class Settings(BaseSettings):
         if v not in allowed:
             raise ValueError(f"log_level must be one of {allowed}")
         return v
+
+    @model_validator(mode="after")
+    def validate_production_secrets(self):
+        if self.environment == "production":
+            if self.jwt_secret_key == "your-secret-key-change-in-production":
+                raise ValueError("jwt_secret_key cannot be the default placeholder in production")
+            if self.storage_secret_key == "storage-secret-key-change-in-production":
+                raise ValueError("storage_secret_key cannot be the default placeholder in production")
+        return self
 
     @property
     def allowed_origins(self) -> List[str]:

--- a/backend/src/routes/transactions.py
+++ b/backend/src/routes/transactions.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+from enum import Enum
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, or_
@@ -14,6 +15,15 @@ settings = get_settings()
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
+class TransactionType(str, Enum):
+    premium = "premium"
+    payout = "payout"
+    refund = "refund"
+
+class TransactionStatus(str, Enum):
+    pending = "pending"
+    successful = "successful"
+    failed = "failed"
 
 @router.get(
     "",
@@ -29,8 +39,8 @@ router = APIRouter(prefix="/transactions", tags=["transactions"])
 async def get_transactions(
     page: int = Query(1, ge=1, description="Page number (starts at 1)"),
     per_page: int = Query(10, ge=1, le=100, description="Items per page (max 100)"),
-    transaction_type: Optional[str] = Query(None, description="Filter by transaction type (e.g., premium, payout)"),
-    status: Optional[str] = Query(None, description="Filter by status (e.g., pending, successful, failed)"),
+    transaction_type: Optional[TransactionType] = Query(None, description="Filter by transaction type (e.g., premium, payout)"),
+    status: Optional[TransactionStatus] = Query(None, description="Filter by status (e.g., pending, successful, failed)"),
     start_date: Optional[datetime] = Query(None, description="Filter transactions from this date (ISO format)"),
     end_date: Optional[datetime] = Query(None, description="Filter transactions until this date (ISO format)"),
     current_user: User = Depends(get_current_active_user),

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -22,6 +22,30 @@ class TestSettingsValidation:
         with pytest.raises(Exception):
             Settings(log_level="INVALID", database_url="sqlite://", jwt_secret_key="k")
 
+    def test_production_rejects_default_jwt_secret(self):
+        from src.config import Settings
+        with pytest.raises(Exception) as excinfo:
+            Settings(environment="production", database_url="sqlite://")
+        assert "jwt_secret_key" in str(excinfo.value)
+        assert "your-secret-key-change-in-production" not in str(excinfo.value)
+
+    def test_production_accepts_custom_jwt_secret(self):
+        from src.config import Settings
+        s = Settings(environment="production", database_url="sqlite://", jwt_secret_key="custom", storage_secret_key="custom2")
+        assert s.jwt_secret_key == "custom"
+
+    def test_production_rejects_default_storage_secret(self):
+        from src.config import Settings
+        with pytest.raises(Exception) as excinfo:
+            Settings(environment="production", database_url="sqlite://", jwt_secret_key="custom")
+        assert "storage_secret_key" in str(excinfo.value)
+        assert "storage-secret-key-change-in-production" not in str(excinfo.value)
+
+    def test_production_accepts_custom_storage_secret(self):
+        from src.config import Settings
+        s = Settings(environment="production", database_url="sqlite://", jwt_secret_key="custom", storage_secret_key="custom2")
+        assert s.storage_secret_key == "custom2"
+
     def test_allowed_origins_development(self):
         from src.config import Settings
         s = Settings(environment="development", database_url="sqlite://", jwt_secret_key="k")

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -125,6 +125,20 @@ def test_get_transactions_filter_by_status(client, authenticated_user, db_sessio
     assert data["transactions"][0]["status"] == "successful"
 
 
+def test_get_transactions_rejects_invalid_type(client, authenticated_user):
+    """Test that invalid transaction types are rejected with 422"""
+    user, headers = authenticated_user
+    response = client.get("/transactions?transaction_type=invalid_type", headers=headers)
+    assert response.status_code == 422
+
+
+def test_get_transactions_rejects_invalid_status(client, authenticated_user):
+    """Test that invalid statuses are rejected with 422"""
+    user, headers = authenticated_user
+    response = client.get("/transactions?status=invalid_status", headers=headers)
+    assert response.status_code == 422
+
+
 def test_get_transactions_filter_by_date_range(client, authenticated_user, db_session):
     """Test filtering by date range"""
     user, headers = authenticated_user


### PR DESCRIPTION
# Summary

This PR strengthens backend configuration security and improves API validation for transaction filtering.

Fixes #352
Fixes #353
Fixes #359
Fixes #360

---

## #352 Production JWT Secret Validation

### Changes

* Added startup validation for JWT secret configuration
* Production environments now reject placeholder JWT secrets
* Error messages identify the misconfigured setting without exposing secret values
* Development and test environments remain unchanged

### Result

Prevents accidental deployment with insecure authentication configuration.

---

## #353 Production Storage Secret Validation

### Changes

* Added startup validation for storage secret configuration
* Production environments now fail fast when placeholder values are used
* Secret contents are never logged or exposed

### Result

Improves security posture and prevents insecure production deployments.

---

## #359 Transaction Type Validation

### Changes

* Added strict validation for transaction_type filter
* Supported values:

  * premium
  * payout
  * refund
* Invalid values are rejected before querying
* OpenAPI documentation updated

### Result

Improves API consistency and prevents invalid query execution.

---

## #360 Transaction Status Validation

### Changes

* Added strict validation for status filter
* Supported values:

  * pending
  * successful
  * failed
* Invalid values return validation errors
* OpenAPI documentation updated

### Result

Improves API reliability and provides stronger request validation.

---

## Testing

### Configuration Tests

* [x] Production rejects placeholder JWT secret
* [x] Production rejects placeholder storage secret
* [x] Development configuration remains functional

### API Validation Tests

* [x] Valid transaction types accepted
* [x] Invalid transaction types rejected
* [x] Valid transaction statuses accepted
* [x] Invalid transaction statuses rejected

### General

* [x] Backend test suite passes
* [x] No regression in existing endpoints
* [x] OpenAPI schema updated

---

## Issues Closed

Fixes #352
Fixes #353
Fixes #359
Fixes #360
