### PR TITLE
feat: implement issues #367, #373, #375, #381

### DIFF
--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -60,6 +60,10 @@ class PolicyNotEligibleForClaimError(StellarInsureError):
     def __init__(self, detail: str = "Policy is not eligible for claims"):
         super().__init__(status.HTTP_400_BAD_REQUEST, detail, "CLAIM_002")
 
+class DuplicatePendingClaimError(StellarInsureError):
+    def __init__(self, detail: str = "A pending claim already exists for this policy"):
+        super().__init__(status.HTTP_409_CONFLICT, detail, "CLAIM_003")
+
 # Storage Errors (STORAGE_xxx)
 class FileNotFoundStorageError(StellarInsureError):
     def __init__(self, detail: str = "File not found"):

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -21,6 +21,7 @@ from .errors import StellarInsureError
 from .schemas import ErrorResponse
 from .database import engine
 from .rate_limiter import setup_rate_limiting
+from .cache import get_redis_client
 
 settings = get_settings()
 
@@ -153,6 +154,24 @@ async def health():
     except Exception as e:
         health_status["status"] = "unhealthy"
         health_status["dependencies"]["database"] = f"error: {str(e)}"
+    
+    # Check Redis when enabled
+    if settings.redis_enabled:
+        try:
+            redis_client = get_redis_client()
+            if redis_client is not None:
+                redis_client.ping()
+                health_status["dependencies"]["redis"] = "connected"
+            else:
+                health_status["dependencies"]["redis"] = "unhealthy"
+                if health_status["status"] != "unhealthy":
+                    health_status["status"] = "degraded"
+        except Exception as e:
+            health_status["dependencies"]["redis"] = f"error: {str(e)}"
+            if health_status["status"] != "unhealthy":
+                health_status["status"] = "degraded"
+    else:
+        health_status["dependencies"]["redis"] = "disabled"
         
     return health_status
 

--- a/backend/src/routes/claims.py
+++ b/backend/src/routes/claims.py
@@ -17,7 +17,8 @@ from ..errors import (
     PolicyNotFoundError,
     PolicyNotEligibleForClaimError,
     InsufficientCoverageError,
-    ClaimNotFoundError
+    ClaimNotFoundError,
+    DuplicatePendingClaimError,
 )
 from ..services.storage_service import storage_service
 from ..services.webhook_service import dispatch_webhook_event
@@ -85,6 +86,9 @@ async def create_claim(
     if claim_data.claim_amount > float(policy.remaining_coverage()):
         raise InsufficientCoverageError()
 
+    if policy.status == PolicyStatus.claim_pending:
+        raise DuplicatePendingClaimError()
+
     claim = Claim(
         policy_id=claim_data.policy_id,
         claimant_id=current_user.id,
@@ -150,6 +154,9 @@ async def create_claim_with_file(
 
     if claim_amount > float(policy.remaining_coverage()):
         raise InsufficientCoverageError()
+
+    if policy.status == PolicyStatus.claim_pending:
+        raise DuplicatePendingClaimError()
 
     # Use StorageService for upload
     file_path = await storage_service.upload_file(file, folder="claim_proofs")

--- a/backend/src/routes/webhooks.py
+++ b/backend/src/routes/webhooks.py
@@ -27,6 +27,11 @@ class WebhookNotFoundError(StellarInsureError):
         super().__init__(status.HTTP_404_NOT_FOUND, detail, "WEBHOOK_001")
 
 
+class WebhookDuplicateUrlError(StellarInsureError):
+    def __init__(self, detail: str = "An active webhook with this URL already exists"):
+        super().__init__(status.HTTP_409_CONFLICT, detail, "WEBHOOK_002")
+
+
 def _format_webhook(webhook: Webhook) -> WebhookResponse:
     return WebhookResponse(
         id=webhook.id,
@@ -55,6 +60,14 @@ async def create_webhook(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_db),
 ):
+    existing = (
+        db.query(Webhook)
+        .filter(Webhook.user_id == current_user.id, Webhook.url == body.url, Webhook.is_active == True)
+        .first()
+    )
+    if existing is not None:
+        raise WebhookDuplicateUrlError()
+
     webhook = Webhook(
         user_id=current_user.id,
         url=body.url,
@@ -143,6 +156,18 @@ async def update_webhook(
         raise WebhookNotFoundError()
 
     if body.url is not None:
+        duplicate = (
+            db.query(Webhook)
+            .filter(
+                Webhook.user_id == current_user.id,
+                Webhook.url == body.url,
+                Webhook.is_active == True,
+                Webhook.id != webhook.id,
+            )
+            .first()
+        )
+        if duplicate is not None:
+            raise WebhookDuplicateUrlError()
         webhook.url = body.url
     if body.event_types is not None:
         webhook.event_types = ",".join(body.event_types)

--- a/smartcontract/src/error.rs
+++ b/smartcontract/src/error.rs
@@ -45,4 +45,5 @@ pub enum Error {
     OracleNotRegistered = 31,
     OracleConditionNotMet = 32,
     ProofTooLong = 33,
+    ClaimAmountOverflow = 34,
 }

--- a/smartcontract/src/lib.rs
+++ b/smartcontract/src/lib.rs
@@ -321,7 +321,7 @@ impl StellarInsure {
 
         if approved {
             claim.approved = true;
-            policy.total_claimed += claim.claim_amount;
+            policy.total_claimed = policy.total_claimed.checked_add(claim.claim_amount).ok_or(Error::ClaimAmountOverflow)?;
             if policy.total_claimed >= policy.coverage_amount {
                 policy.status = PolicyStatus::ClaimApproved;
             } else {
@@ -995,7 +995,7 @@ impl StellarInsure {
             let mut claim = storage::get_claim(&env, policy_id)?;
             
             claim.approved = true;
-            policy.total_claimed += claim.claim_amount;
+            policy.total_claimed = policy.total_claimed.checked_add(claim.claim_amount).ok_or(Error::ClaimAmountOverflow)?;
             if policy.total_claimed >= policy.coverage_amount {
                 policy.status = PolicyStatus::ClaimApproved;
             } else {

--- a/smartcontract/src/test.rs
+++ b/smartcontract/src/test.rs
@@ -1463,3 +1463,37 @@ fn test_partial_claim_exceeding_remaining_coverage_is_rejected() {
     // Second claim attempts to take more than what's remaining (which is 50_000)
     client.submit_claim(&policy_id, &100_000, &String::from_str(&env, "proof2"));
 }
+
+// ── Issue #381 — Checked arithmetic ───────────────────────────────────────────
+
+#[test]
+fn test_vote_claim_accumulates_total_claimed_with_checked_add() {
+    let (env, contract_id, admin, policyholder, _token) = setup_insurance_contract();
+    let client = StellarInsureClient::new(&env, &contract_id);
+
+    let second_admin = Address::generate(&env);
+    client.add_admin(&admin, &second_admin);
+    client.set_threshold(&admin, &2);
+
+    let premium = client.calculate_premium(&PolicyType::Weather, &1_000_000, &2_592_000);
+    let policy_id = client.create_policy(
+        &policyholder,
+        &PolicyType::Weather,
+        &1_000_000,
+        &premium,
+        &2_592_000,
+        &String::from_str(&env, "temperature < 0"),
+    );
+
+    // First claim — vote to approve
+    client.submit_claim(&policy_id, &300_000, &String::from_str(&env, "proof1"));
+    client.vote_claim(&policy_id, &admin, &true);
+    client.vote_claim(&policy_id, &second_admin, &true);
+    assert_eq!(client.get_policy(&policy_id).total_claimed, 300_000);
+
+    // Second claim — vote to approve
+    client.submit_claim(&policy_id, &200_000, &String::from_str(&env, "proof2"));
+    client.vote_claim(&policy_id, &admin, &true);
+    client.vote_claim(&policy_id, &second_admin, &true);
+    assert_eq!(client.get_policy(&policy_id).total_claimed, 500_000);
+}


### PR DESCRIPTION
## Summary

### #367 — Backend: Prevent duplicate pending claims for one policy
- Added `DuplicatePendingClaimError` (CLAIM_003, 409 conflict)
- Check `policy.status == PolicyStatus.claim_pending` before creating a new claim
- Applied to both text-based and file-upload claim endpoints

### #373 — Backend: Prevent duplicate webhook URLs for the same user
- Added `WebhookDuplicateUrlError` (WEBHOOK_002, 409 conflict)
- On create: reject if same user has an active webhook with the same URL
- On update: reject if another active webhook (excluding current) has the target URL
- Different users may still use the same URL

### #375 — Backend: Check Redis dependency in health endpoint
- `/health` now includes Redis status when `redis_enabled` is true
- Reports `connected`, `unhealthy`, or `disabled` states
- Overall status goes to `degraded` when Redis fails but DB is healthy
- Database health behavior remains unchanged

### #381 — Contracts: Use checked addition when approving claims
- Replaced `policy.total_claimed += claim.claim_amount` with `checked_add` in both `process_claim` and `vote_claim`
- Added `ClaimAmountOverflow` error variant (code 34)
- Added test verifying accumulation works correctly with multi-sig voting

closes #367
closes #373
closes #375 
closes #381