### PR TITLE
fix: resolve issues #387, #395, #400, #401

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,6 +29,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Check Alembic migrations apply cleanly
+        env:
+          ENVIRONMENT: test
+          DATABASE_URL: sqlite:///ci_test.db
+          JWT_SECRET_KEY: ci-test-secret
+        run: alembic upgrade head
+
       - name: Run backend unit tests with coverage
         env:
           ENVIRONMENT: test

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ yarn-error.log*
 *.db
 *.sqlite
 
+# Coverage
+**/.coverage
+**/coverage.xml
+
 # Python
 __pycache__/
 *.py[cod]

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -39,3 +39,29 @@ kubectl apply -k k8s/overlays/production
 
 - Backend/frontend deployments use `RollingUpdate` with `maxUnavailable: 0`.
 - HPA scales backend pods between 2 and 8 replicas based on CPU utilization.
+
+## Secret Rotation
+
+Regularly rotate all long-lived secrets to limit the blast radius of a credential leak. Below is a per-secret rotation guide for the entries in `k8s/base/secret-template.yaml`.
+
+| Secret key | Rotation trigger | User/session impact | Recommended steps |
+|---|---|---|---|
+| `JWT_SECRET_KEY` | Every 90 days or on compromise | All active sessions invalidated; users must re-authenticate. | 1. Generate new key: `openssl rand -hex 64`<br>2. Update the Secret and rollout the backend.<br>3. Old tokens are rejected immediately — warn users before rotation. |
+| `DATABASE_URL` | On credential leak only | Brief connection drain; in-flight queries fail and must be retried. | 1. Update `POSTGRES_PASSWORD` first (see below).<br>2. Apply new Secret; backend pods will reconnect via pooled connections.<br>3. Monitor for `FATAL: password authentication failed` during the window. |
+| `STELLAR_ADMIN_SECRET` | Every 180 days or on compromise | No direct user impact; contract admin operations may fail until updated. | 1. Generate a new Stellar keypair: `stellar keys generate --fund testnet`.<br>2. Update the Secret and rollout.<br>3. Transfer contract ownership or update admin reference in the contract if the address changed. |
+| `STELLAR_ADMIN_PUBLIC` | In lockstep with `STELLAR_ADMIN_SECRET` | None — derived from the secret. | Update alongside the secret above. |
+| `STELLAR_CONTRACT_ID` | On contract upgrade or re-deployment | Operations targeting the old contract ID fail until clients refresh. | 1. Deploy new contract and verify.<br>2. Update the Secret and rollout backend.<br>3. Announce the new contract ID to downstream consumers. |
+| `STORAGE_SECRET_KEY` | Every 90 days | Stored files remain accessible; new uploads signed with old key fail silently. | 1. Generate new key: `openssl rand -hex 32`.<br>2. Apply new Secret; backend rotates signing key at next startup.<br>3. Verify upload / download flows in staging first. |
+| `WEBHOOK_SECRET_KEY` | Every 90 days or on compromise | Webhook payloads signed with the old key fail HMAC verification on the consumer side. | 1. Generate new key: `openssl rand -hex 32`.<br>2. Coordinate with webhook consumers to accept both old and new signatures during a transition window.<br>3. Apply new Secret and remove old consumer key after one week. |
+| `POSTGRES_PASSWORD` | Every 180 days or on credential leak | Active connections drain; brief read/write failures while pods reconnect. | 1. Update the password in PostgreSQL first: `ALTER USER postgres PASSWORD 'new-password';`<br>2. Update the Secret and rollout backend.<br>3. **Staging → Production** — always test the rotation on staging first.<br>4. ⚠️ **WARNING** — Rotating the database password will briefly interrupt all services that depend on the database. Plan during a maintenance window. |
+| `REDIS_PASSWORD` | Every 180 days or on compromise | Cache entries are lost if Redis restarts; brief increase in backend latency. | 1. Update Redis password: `CONFIG SET requirepass "new-password"`.<br>2. Apply new Secret; backend caches will reconnect transparently.<br>3. If enabled for sessions, expect all users to be logged out. |
+
+### General rotation procedure
+
+1. **Generate** the new secret value using a secure random source (openssl, `stellar keys`, or your vault).
+2. **Apply** the updated manifest: `kubectl apply -k k8s/overlays/<environment>`.
+3. **Rollout** the affected pods: `kubectl rollout restart deployment/<name>`.
+4. **Verify** the deployment is healthy and the new secret is picked up.
+5. **Invalidate** old secrets when the rotation window closes.
+
+> **⚠️ HIGH IMPACT** — Database and Redis password rotations affect all connected services. Always test in staging before production and schedule outside business hours.

--- a/docs/SMARTCONTRACT.md
+++ b/docs/SMARTCONTRACT.md
@@ -57,3 +57,153 @@ The risk pool contract manages liquidity-provider balances and yield distributio
 - `("pool", "withdraw")`
 - `("pool", "yield")`
 - `("pool", "claim")`
+
+## Initialization Runbook
+
+This runbook describes the ordered steps to deploy and initialize the StellarInsure smart contracts on a Soroban-compatible testnet (e.g. Futurenet / Testnet).
+
+### Prerequisites
+
+| Item | Requirement |
+|---|---|
+| Soroban CLI | `soroban` version 21+ installed and configured |
+| Network | Testnet RPC URL (e.g. `https://rpc-futurenet.stellar.org`) |
+| Network passphrase | `Test SDF Network ; September 2015` (Testnet) |
+| Admin keypair | A funded Stellar account with enough XLM for deploy + initialization |
+| Premium token | A Stellar asset contract (Classic asset or SAC) to use for premiums/payouts |
+| Optional: oracle addresses | Pre-deployed oracle contracts if using automatic claim triggers |
+
+### Step-by-step
+
+#### 1. Deploy main contract
+
+```bash
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/stellarinsure.wasm \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE>
+```
+
+Save the returned contract ID as `CONTRACT_ID`.
+
+#### 2. Deploy RiskPool contract
+
+```bash
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/risk_pool.wasm \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE>
+```
+
+Save the returned contract ID as `RISK_POOL_ID`.
+
+#### 3. Initialize main contract
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE> \
+  -- \
+  init \
+  --admin <ADMIN_PUBLIC>
+```
+
+#### 4. Set premium token
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE> \
+  -- \
+  set_premium_token \
+  --admin <ADMIN_PUBLIC> \
+  --token <PREMIUM_TOKEN_ADDRESS>
+```
+
+#### 5. Initialize RiskPool
+
+```bash
+soroban contract invoke \
+  --id <RISK_POOL_ID> \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE> \
+  -- \
+  init \
+  --admin <ADMIN_PUBLIC>
+```
+
+#### 6. Link RiskPool to main contract
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE> \
+  -- \
+  set_risk_pool \
+  --admin <ADMIN_PUBLIC> \
+  --risk_pool <RISK_POOL_ID>
+```
+
+#### 7. (Optional) Register oracle
+
+Repeat for each oracle type needed:
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> \
+  --network-passphrase <PASSPHRASE> \
+  -- \
+  register_oracle \
+  --admin <ADMIN_PUBLIC> \
+  --oracle_type <ORACLE_TYPE_SYMBOL> \
+  --oracle_address <ORACLE_CONTRACT_ID>
+```
+
+#### 8. Verify deployment
+
+```bash
+# Check contract version
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> --network-passphrase <PASSPHRASE> \
+  -- version
+
+# Check contract is not paused
+soroban contract invoke --id <CONTRACT_ID> --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> --network-passphrase <PASSPHRASE> \
+  -- get_paused
+
+# Check risk pool config
+soroban contract invoke --id <RISK_POOL_ID> --source <ADMIN_SECRET> \
+  --rpc-url <RPC_URL> --network-passphrase <PASSPHRASE> \
+  -- get_reserve_ratio
+```
+
+### Rollback / retry notes
+
+| Failure point | Action |
+|---|---|
+| Contract deploy fails (insufficient balance) | Fund the admin account with more XLM and retry the deploy. |
+| `init` returns `AlreadyInitialized` | The contract was already initialized — skip to step 4. This is safe. |
+| `set_premium_token` fails with `Unauthorized` | Verify the admin address and secret match the account used in `init`. |
+| RiskPool not linked | Invoking `pay_premium` will work but premiums will not flow to the pool. Run step 6 to link. |
+| Oracle registration fails | The contract can operate without oracles; manual claim processing still works. Retry after fixing the oracle address. |
+| Any step fails mid-way | Steps are **not** transactional — you can safely retry any step individually. No partial state is left behind that blocks re-execution. |
+| Wrong network | Ensure `--rpc-url` and `--network-passphrase` match. Deploy on the wrong network means starting over with the correct RPC. |
+
+### Network assumptions
+
+- The admin keypair must be **funded** with sufficient XLM to cover deploy fees and contract storage rent.
+- The premium token **must** be a pre-deployed Stellar Asset Contract (SAC). Classic assets are not directly supported.
+- The risk pool contract **should** be initialized before it receives token transfers from the main contract. If it receives tokens before `init`, they may be unrecoverable.
+- Oracle contracts must conform to the `OracleProvider` trait defined in `oracle.rs`. Stub oracles (`WeatherOracle`, `FlightOracle`, etc.) are built into the contract for development use and do not require external registration.

--- a/smartcontract/src/test.rs
+++ b/smartcontract/src/test.rs
@@ -1408,6 +1408,120 @@ fn test_default_reserve_ratio_is_20_percent() {
     assert_eq!(ratio, 2000); // 20%
 }
 
+// ── Issue #387 — Provider unregister after full withdrawal ───────────────────
+
+#[test]
+fn test_full_withdrawal_removes_provider() {
+    let (env, _contract_id, admin, provider_one, _provider_two) = setup_risk_pool();
+    let client = RiskPoolClient::new(&env, &_contract_id);
+
+    // Disable reserve so full withdrawal is possible
+    client.set_reserve_ratio(&admin, &0);
+
+    client.add_liquidity(&provider_one, &1_000);
+
+    // Full withdrawal — no accrued yield
+    client.withdraw_liquidity(&provider_one, &1_000);
+
+    // Provider should no longer be in the registered list
+    let stats = client.get_pool_stats();
+    assert_eq!(stats.provider_count, 0);
+
+    // Provider position should be removed entirely
+    let result = client.try_get_provider_position(&provider_one);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_partial_withdrawal_keeps_provider_registered() {
+    let (env, _contract_id, admin, provider_one, _provider_two) = setup_risk_pool();
+    let client = RiskPoolClient::new(&env, &_contract_id);
+
+    // Disable reserve so any withdrawal is possible
+    client.set_reserve_ratio(&admin, &0);
+
+    client.add_liquidity(&provider_one, &1_000);
+
+    // Partial withdrawal
+    client.withdraw_liquidity(&provider_one, &400);
+
+    let stats = client.get_pool_stats();
+    assert_eq!(stats.provider_count, 1);
+
+    let position = client.get_provider_position(&provider_one);
+    assert_eq!(position.contribution, 600);
+}
+
+#[test]
+fn test_full_withdrawal_with_multiple_providers_only_removes_correct_one() {
+    let (env, _contract_id, admin, provider_one, provider_two) = setup_risk_pool();
+    let client = RiskPoolClient::new(&env, &_contract_id);
+
+    // Disable reserve so full withdrawal is possible
+    client.set_reserve_ratio(&admin, &0);
+
+    client.add_liquidity(&provider_one, &1_000);
+    client.add_liquidity(&provider_two, &2_000);
+
+    // Full withdrawal of provider_one
+    client.withdraw_liquidity(&provider_one, &1_000);
+
+    // Provider two should still be registered
+    let stats = client.get_pool_stats();
+    assert_eq!(stats.provider_count, 1);
+
+    let position_two = client.get_provider_position(&provider_two);
+    assert_eq!(position_two.contribution, 2_000);
+
+    // Provider one should be gone
+    let result = client.try_get_provider_position(&provider_one);
+    assert!(result.is_err());
+}
+
+#[test]
+#[should_panic]
+fn test_full_withdrawal_removes_provider_after_claiming_yield() {
+    let (env, _contract_id, admin, provider_one, _provider_two) = setup_risk_pool();
+    let client = RiskPoolClient::new(&env, &_contract_id);
+
+    // Disable reserve so full withdrawal is possible
+    client.set_reserve_ratio(&admin, &0);
+
+    client.add_liquidity(&provider_one, &1_000);
+    client.distribute_yield(&100);
+
+    // Claim yield so accrued_yield drops to zero
+    client.claim_yield(&provider_one);
+
+    // Now full withdrawal should remove provider (contribution=0, accrued_yield=0)
+    client.withdraw_liquidity(&provider_one, &1_000);
+
+    // Should NOT be able to get position
+    client.get_provider_position(&provider_one);
+}
+
+#[test]
+fn test_provider_retained_when_only_yield_remains() {
+    let (env, _contract_id, admin, provider_one, _provider_two) = setup_risk_pool();
+    let client = RiskPoolClient::new(&env, &_contract_id);
+
+    // Disable reserve so full withdrawal is possible
+    client.set_reserve_ratio(&admin, &0);
+
+    client.add_liquidity(&provider_one, &1_000);
+    client.distribute_yield(&100);
+
+    // Withdraw full contribution — provider should stay because accrued_yield > 0
+    client.withdraw_liquidity(&provider_one, &1_000);
+
+    let stats = client.get_pool_stats();
+    assert_eq!(stats.provider_count, 1);
+
+    let position = client.get_provider_position(&provider_one);
+    assert_eq!(position.contribution, 0);
+    assert_eq!(position.accrued_yield, 100);
+}
+
 #[test]
 fn test_multiple_partial_claims_accumulate_correctly() {
     let (env, contract_id, _admin, policyholder, _token) = setup_insurance_contract();


### PR DESCRIPTION
This PR addresses 4 issues across documentation, CI, and contract testing.

### Changes

#### 📖 Issue #401 — Kubernetes secret rotation notes
Added a comprehensive secret rotation guide to `docs/KUBERNETES.md` covering all 9 secrets from `k8s/base/secret-template.yaml`. Each entry documents rotation trigger, user/session impact, and step-by-step rotation instructions. Includes a general rotation procedure and a HIGH IMPACT warning for database/Redis password rotations.

#### 🔧 Issue #395 — Alembic migration check in backend CI
Added a new CI step in `.github/workflows/backend-ci.yml` that runs `alembic upgrade head` against a file-based SQLite database before the test step. The migration check runs independently so it does not interfere with the existing in-memory SQLite test setup. CI will now fail if migrations are broken.

#### 🧪 Issue #387 — Provider unregister after full withdrawal test
Added 5 focused tests in `smartcontract/src/test.rs`:
- `test_full_withdrawal_removes_provider` — verifies provider is removed from registered list and position is deleted after full withdrawal with no yield
- `test_partial_withdrawal_keeps_provider_registered` — verifies partial withdrawal keeps the provider registered
- `test_full_withdrawal_with_multiple_providers_only_removes_correct_one` — verifies only the correct provider is removed
- `test_full_withdrawal_removes_provider_after_claiming_yield` — verifies provider is removed after claiming yield then fully withdrawing
- `test_provider_retained_when_only_yield_remains` — verifies provider stays registered when only accrued yield remains

#### 📖 Issue #400 — Smart contract initialization runbook
Added an ordered initialization runbook to `docs/SMARTCONTRACT.md` covering:
- Prerequisites table (CLI, network, keypair, token, oracles)
- 8-step deployment and initialization sequence with `soroban` CLI commands
- Rollback/retry notes for each failure point
- Network assumptions and best practices

### Files changed
- `.github/workflows/backend-ci.yml` — added alembic migration check step
- `docs/KUBERNETES.md` — added secret rotation guide
- `docs/SMARTCONTRACT.md` — added initialization runbook
- `smartcontract/src/test.rs` — added provider unregister tests
- `.gitignore` — added coverage files to gitignore

Closes #387
Closes #395
Closes #400
Closes #401