### PR TITLE
Fix healthchecks, add staging smoke test, add auth and oracle docs (#…

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -33,6 +33,42 @@ jobs:
         if: ${{ secrets.STAGING_KUBECONFIG == '' }}
         run: echo "Set STAGING_KUBECONFIG secret to enable automated staging deploy."
 
+  smoke-test:
+    runs-on: ubuntu-latest
+    environment: staging
+    needs: deploy-staging
+    steps:
+      - name: Check backend health
+        if: ${{ secrets.STAGING_BACKEND_URL != '' }}
+        run: |
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$STAGING_BACKEND_URL/health")
+          echo "Backend /health → HTTP $STATUS"
+          [ "$STATUS" = "200" ]
+        env:
+          STAGING_BACKEND_URL: ${{ secrets.STAGING_BACKEND_URL }}
+
+      - name: Check frontend
+        if: ${{ secrets.STAGING_FRONTEND_URL != '' }}
+        run: |
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$STAGING_FRONTEND_URL/")
+          echo "Frontend / → HTTP $STATUS"
+          [ "$STATUS" = "200" ]
+        env:
+          STAGING_FRONTEND_URL: ${{ secrets.STAGING_FRONTEND_URL }}
+
+      - name: Check authenticated path returns 401
+        if: ${{ secrets.STAGING_BACKEND_URL != '' }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Accept: application/json" "$STAGING_BACKEND_URL/policies")
+          echo "GET /policies (no auth) → HTTP $STATUS"
+          [ "$STATUS" = "401" ]
+        env:
+          STAGING_BACKEND_URL: ${{ secrets.STAGING_BACKEND_URL }}
+
+      - name: Smoke test secrets reminder
+        if: ${{ secrets.STAGING_BACKEND_URL == '' }}
+        run: echo "Set STAGING_BACKEND_URL and STAGING_FRONTEND_URL to enable smoke tests."
+
   seed-staging-data:
     runs-on: ubuntu-latest
     environment: staging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 10s
 
   redis:
     image: redis:7-alpine
@@ -26,6 +27,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      start_period: 5s
 
   backend:
     build:
@@ -47,6 +49,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 30s
 
   frontend:
     build:
@@ -60,12 +63,14 @@ services:
     env_file:
       - .env.docker
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 30s
 
 volumes:
   postgres_data:

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,225 @@
+# Auth Flow for Integrators
+
+## Overview
+
+StellarInsure uses Stellar wallet signature verification for authentication. Users prove ownership of a Stellar keypair by signing a message, and the backend issues JWT tokens for subsequent requests.
+
+This is **not** SEP-10. There is no challenge endpoint or structured handshake — the client constructs a message, signs it locally, and sends the signature directly to `/auth/login`.
+
+---
+
+## Auth Sequence
+
+```
+1. Client chooses a message to sign (e.g. a timestamped nonce)
+   ↓
+2. Client signs the message with the Stellar private key (Ed25519)
+   ↓
+3. POST /auth/login  { stellar_address, message, signature }
+   ↓
+4. Backend verifies the signature against the public key
+   ↓
+5. Backend returns access_token + refresh_token
+   ↓
+6. Client includes access_token in Authorization header for all requests
+   ↓
+7. When access_token expires, POST /auth/refresh to get new tokens
+```
+
+New users are automatically created on first login — there is no separate registration step required.
+
+---
+
+## Step 1 — Construct a message
+
+The backend does not enforce a specific message format; it only verifies that the signature matches whatever message is sent. Use a timestamped nonce to prevent replay across sessions:
+
+```
+Sign in to StellarInsure: <unix_timestamp>
+```
+
+Example:
+```
+Sign in to StellarInsure: 1714204800
+```
+
+---
+
+## Step 2 — Sign with Freighter
+
+```javascript
+import freighter from "@stellar/freighter-api";
+
+const message = `Sign in to StellarInsure: ${Math.floor(Date.now() / 1000)}`;
+const { signedMessage } = await freighter.signMessage(message);
+// signedMessage is a base64-encoded Ed25519 signature
+```
+
+### Sign with stellar-sdk (server/testing)
+
+```javascript
+import { Keypair } from "@stellar/stellar-sdk";
+
+const keypair = Keypair.fromSecret("S...");
+const message = `Sign in to StellarInsure: ${Math.floor(Date.now() / 1000)}`;
+const msgBytes = Buffer.from(message, "utf8");
+const signature = keypair.sign(msgBytes).toString("base64");
+```
+
+```python
+from stellar_sdk import Keypair
+import base64, time
+
+keypair = Keypair.from_secret("S...")
+message = f"Sign in to StellarInsure: {int(time.time())}"
+signature = base64.b64encode(keypair.sign(message.encode())).decode()
+```
+
+---
+
+## Step 3 — Login
+
+**Endpoint:** `POST /auth/login`
+
+**Rate limit:** 10 requests / minute per IP
+
+**Request body:**
+
+```json
+{
+  "stellar_address": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "message": "Sign in to StellarInsure: 1714204800",
+  "signature": "<base64-encoded Ed25519 signature>"
+}
+```
+
+**curl example:**
+
+```bash
+curl -X POST https://api.example.com/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "stellar_address": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    "message": "Sign in to StellarInsure: 1714204800",
+    "signature": "ABC123...base64..."
+  }'
+```
+
+**Response (200):**
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "bearer",
+  "expires_in": 1800
+}
+```
+
+**Error responses:**
+
+| HTTP | Code | Meaning |
+|------|------|---------|
+| 401 | AUTH_001 | Signature is invalid or does not match the message |
+| 429 | — | Rate limit exceeded |
+
+---
+
+## Token Lifetimes and Headers
+
+| Token | Lifetime | Usage |
+|-------|----------|-------|
+| `access_token` | 30 minutes (`expires_in: 1800`) | Sent as `Authorization: Bearer <token>` on every request |
+| `refresh_token` | 7 days | Sent to `POST /auth/refresh` to obtain a new token pair |
+
+**JWT claims** (decoded payload):
+
+```json
+{
+  "sub": "42",
+  "stellar_address": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "exp": 1714206600,
+  "type": "access"
+}
+```
+
+- `sub` — internal user ID (integer as string)
+- `stellar_address` — Stellar public key
+- `exp` — expiry as Unix timestamp
+- `type` — `"access"` or `"refresh"`; the backend rejects access tokens presented to `/auth/refresh` and vice versa
+
+---
+
+## Step 4 — Authenticated Requests
+
+Include the access token in every request:
+
+```bash
+curl https://api.example.com/policies \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+A missing or invalid token returns:
+
+```json
+HTTP 401
+{
+  "error": { "code": "AUTH_002", "message": "User not found" }
+}
+```
+
+An expired token returns HTTP 401 with code `AUTH_004`.
+
+---
+
+## Step 5 — Refresh Tokens
+
+**Endpoint:** `POST /auth/refresh`
+
+```bash
+curl -X POST https://api.example.com/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."}'
+```
+
+**Response (200):** same shape as login — a new `access_token` and `refresh_token`.
+
+**Error:** HTTP 401 if the refresh token is expired or has the wrong type.
+
+When the refresh token itself expires (after 7 days), the user must sign again via `/auth/login`.
+
+---
+
+## How Signature Verification Works
+
+The backend uses the Stellar Python SDK's `Keypair.verify()`:
+
+```python
+keypair = Keypair.from_public_key(stellar_address)
+keypair.verify(
+    data=message.encode("utf-8"),
+    signature=base64.b64decode(signature),
+)
+```
+
+This is a standard Ed25519 signature check. The signature must be a base64-encoded raw Ed25519 signature (64 bytes) over the UTF-8 bytes of the message string.
+
+---
+
+## Error Code Reference
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| AUTH_001 | 401 | Invalid wallet signature |
+| AUTH_002 | 401 | User not found |
+| AUTH_003 | 400 | User already exists (only relevant on `/auth/register`) |
+| AUTH_004 | 401 | Token expired or invalid |
+
+---
+
+## Notes for Integrators
+
+- **`/auth/login` vs `/auth/register`:** Both accept the same request body and perform the same signature check. `/auth/login` auto-creates a new user record on first login. You do not need to call `/auth/register` separately.
+- **Session storage:** The reference frontend stores the session in `sessionStorage` under the key `stellarinsure-session` and clears it on tab close.
+- **Logout:** `POST /auth/logout` is a client-side operation only — the backend is stateless and does not invalidate tokens. Discard tokens client-side.
+- **Account deletion:** `DELETE /auth/me` requires re-authentication (send the same body as `/auth/login`). It soft-deletes the account, cancels active policies, and anonymises personal data.

--- a/docs/ORACLE.md
+++ b/docs/ORACLE.md
@@ -468,6 +468,187 @@ For sensitive data (health records, personal information):
    - Reveal only necessary information
    - Minimize data exposure
 
+## Signed Payload Schema
+
+Every oracle payload the relay service accepts has the following envelope fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oracle_type` | string | yes | One of `"weather"`, `"flight"`, `"smart_contract"`, `"asset_price"` |
+| `timestamp` | integer | yes | Unix timestamp (seconds) when the data was collected |
+| `data` | object | yes | Type-specific measurement values (see oracle type sections above) |
+| `sources` | array | yes | One or more provider objects, each with `provider` (string) and `confidence` (float 0–1) |
+| `signature` | string | yes | Base64-encoded Ed25519 signature over the canonical payload (see below) |
+
+For type-specific fields (`location`, `flight`, `contract`, `asset`) see the data format examples in each oracle type section above.
+
+### Signature Algorithm
+
+The oracle node signs the payload as follows:
+
+1. Serialize the payload to UTF-8 JSON with the `signature` key **omitted**. Keys must be in the same order as the schema above; do not add whitespace.
+2. Sign the UTF-8 bytes with the oracle node's Stellar Ed25519 private key using `Keypair.sign()`.
+3. Base64-encode the 64-byte raw signature and set it as the `signature` field.
+
+```python
+import json, base64
+from stellar_sdk import Keypair
+
+keypair = Keypair.from_secret("S...")  # oracle node's signing key
+
+payload = {
+    "oracle_type": "weather",
+    "timestamp": 1714204800,
+    "data": {"temperature": -2.5, "rainfall_24h": 0.0, "wind_speed": 15.3, "humidity": 65},
+    "sources": [{"provider": "NOAA", "confidence": 0.95}],
+}
+
+canonical = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+payload["signature"] = base64.b64encode(keypair.sign(canonical)).decode()
+```
+
+The oracle node's public key **must** match the address registered on-chain for that oracle type (see `register_oracle` below). The relay service verifies the signature with `stellar_service.verify_stellar_signature(public_key, signature, canonical_payload)` before trusting the data.
+
+> **Important:** Signature verification is performed **off-chain** by the backend relay service. The on-chain `OracleProvider` implementations (`WeatherOracle`, `FlightOracle`, etc.) are dispatch stubs and do not re-verify signatures. Trust enforcement happens before data reaches the contract.
+
+### Complete Signed Weather Payload Example
+
+```json
+{
+  "oracle_type": "weather",
+  "location": {
+    "latitude": 40.7128,
+    "longitude": -74.0060,
+    "city": "New York"
+  },
+  "timestamp": 1714204800,
+  "data": {
+    "temperature": -2.5,
+    "rainfall_24h": 0.0,
+    "wind_speed": 15.3,
+    "humidity": 65
+  },
+  "sources": [
+    {"provider": "NOAA", "confidence": 0.95},
+    {"provider": "OpenWeatherMap", "confidence": 0.92}
+  ],
+  "signature": "BASE64_ED25519_SIG_OVER_PAYLOAD_WITHOUT_SIGNATURE_FIELD"
+}
+```
+
+---
+
+## Contract-Side Verification (End to End)
+
+### Prerequisites
+
+1. The contract must be initialised (`init`) with an admin address.
+2. A premium token and optionally a risk pool must be set via `set_premium_token` / `set_risk_pool`.
+3. An oracle address must be registered for each oracle type used.
+
+### Step 0 — Submit a Claim First
+
+`evaluate_oracle_trigger` requires the policy to already be in `ClaimPending` status. The policyholder must call `submit_claim` before the relay can trigger automatic evaluation:
+
+```rust
+// Policyholder submits a claim
+contract.submit_claim(&env, policy_id, claim_amount, proof)?;
+// Policy status is now ClaimPending
+```
+
+### Step 1 — Register the Oracle (admin)
+
+```rust
+// Register the oracle node's Stellar address on-chain
+contract.register_oracle(
+    &env,
+    admin,
+    symbol_short!("Weather"),     // oracle_type
+    oracle_node_address,          // must match signing keypair
+)?;
+```
+
+The registered address is stored by `storage::set_oracle_address` and checked before any oracle trigger evaluation.
+
+### Step 2 — Off-chain Relay Verifies Signature
+
+Before submitting data to the contract, the backend relay service verifies the oracle node's signature:
+
+```python
+is_valid = await stellar_service.verify_stellar_signature(
+    public_key=oracle_node_stellar_address,
+    signature=payload["signature"],
+    message=canonical_json_without_signature_field,
+)
+if not is_valid:
+    raise ValueError("Oracle signature verification failed — data rejected")
+```
+
+### Step 3 — Relay Calls `evaluate_oracle_trigger`
+
+```rust
+contract.evaluate_oracle_trigger(
+    &env,
+    policy_id,
+    symbol_short!("Weather"),   // oracle_type — must be registered
+    symbol_short!("temp"),      // parameter — passed to oracle provider
+)?;
+```
+
+Source: `smartcontract/src/lib.rs:507–593`
+
+### Step 4 — Contract Dispatches to Oracle Provider
+
+```rust
+// lib.rs:386–405
+pub fn verify_oracle_condition(env, oracle_type, parameter) -> Result<OracleResult, Error> {
+    if oracle_type == symbol_short!("Weather") {
+        WeatherOracle::verify_condition(&env, parameter)
+    } else if oracle_type == symbol_short!("Flight") {
+        FlightOracle::verify_condition(&env, parameter)
+    } else if oracle_type == symbol_short!("Price") {
+        PriceOracle::verify_condition(&env, parameter)
+    } else {
+        SmartContractOracle::verify_condition(&env, parameter)
+    }
+}
+```
+
+Each provider returns `OracleResult { is_verified: bool, details: String }`.
+
+### Step 5 — Auto-Approve Claim if Condition Met
+
+```rust
+// lib.rs:542
+if oracle_result.is_verified {
+    // Claim is approved, payout transferred, PolicyStatus → ClaimApproved
+    // AutomaticClaimTriggered and Payout events are emitted
+}
+```
+
+If `is_verified` is `false`, the contract returns `Error::OracleConditionNotMet` and the claim remains pending.
+
+### Full Call Chain Summary
+
+```
+Policyholder → submit_claim()
+                        ↓
+Backend relay: verify oracle signature (off-chain, stellar_service)
+                        ↓
+Admin registers oracle: register_oracle(oracle_type, oracle_address)
+                        ↓
+Relay → evaluate_oracle_trigger(policy_id, oracle_type, parameter)
+                        ↓
+Contract → verify_oracle_condition(oracle_type, parameter)
+                        ↓
+OracleProvider::verify_condition() → OracleResult { is_verified }
+                        ↓
+is_verified == true → claim approved + payout transferred
+is_verified == false → Error::OracleConditionNotMet
+```
+
+---
+
 ## Future Enhancements
 
 ### Chainlink Integration


### PR DESCRIPTION
  Summary

  Resolves #445, #448, #449, #444

  #445 — Docker Compose healthchecks and startup ordering

  - Added start_period to all four service healthchecks (postgres: 10s, redis: 5s, backend: 30s, frontend: 30s) so
  container restart failures during image startup do not count against retry limits
  - Fixed frontend.depends_on from a plain list to condition: service_healthy so the frontend waits for the backend
  healthcheck to pass before starting

  #448 — Staging deployment smoke test

  - Added a smoke-test job to .github/workflows/staging-deploy.yml that runs after deploy-staging
  - Checks: GET /health → 200, GET / (frontend) → 200, GET /policies (no auth) → 401
  - All checks are read-only and safe to run repeatedly; a failed check fails the job visibly in CI
  - Follows the existing pattern of printing a reminder when required secrets are not set

  #449 — SEP-10 and JWT auth flow documentation

  - Created docs/AUTH.md: standalone integrator reference covering the full wallet-signature auth sequence, how to sign
  messages with Freighter and stellar-sdk, token lifetimes (access: 30 min, refresh: 7 days), JWT claim fields, curl
  examples for login/refresh/authenticated requests, and error code table

  #444 — Signed oracle payload schema and verifier contract

  - Added Signed Payload Schema section to docs/ORACLE.md: field-by-field table, Ed25519 signing algorithm with Python
  example, complete signed weather payload, and a note clarifying signature verification is off-chain (backend relay),
  not re-verified on-chain
  - Added Contract-Side Verification (End to End) section: full call chain from submit_claim → relay signature check →
  register_oracle → evaluate_oracle_trigger → verify_oracle_condition → OracleResult.is_verified → auto-payout; includes
  prerequisite note that ClaimPending status is required before evaluate_oracle_trigger

  Test plan

  - [ ] docker compose config shows condition: service_healthy on all depends_on entries and start_period in all four
  healthchecks
  - [ ] docker compose up on a clean state starts services in dependency order without premature health failures
  - [ ] Staging workflow YAML is valid (push to a release/** branch); smoke-test job appears, depends on deploy-staging,
  and fails the pipeline on unexpected HTTP status
  - [ ] docs/AUTH.md exists; curl login example matches the actual /auth/login schema (stellar_address, message,
  signature)
  - [ ] docs/ORACLE.md new sections present; OracleResult field documented as is_verified (not condition_met)

  Closes #445, closes #448, closes #449, closes #444