### PR TITLE
Add draft persistence, rate-limit headers, webhook dead letters, and …

### DIFF
--- a/backend/alembic/versions/005_add_webhook_delivery_status.py
+++ b/backend/alembic/versions/005_add_webhook_delivery_status.py
@@ -1,0 +1,26 @@
+"""add webhook delivery status tracking
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-05-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "webhook_deliveries",
+        sa.Column("delivery_status", sa.String(length=32), nullable=False, server_default="pending"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("webhook_deliveries", "delivery_status")

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -184,6 +184,7 @@ class WebhookDelivery(Base):
     response_body = Column(Text, nullable=True)
     success = Column(Boolean, default=False, nullable=False)
     attempts = Column(Integer, default=0, nullable=False)
+    delivery_status = Column(String(32), default="pending", nullable=False)
     last_attempt_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
@@ -192,6 +193,7 @@ class WebhookDelivery(Base):
     def __init__(self, **kwargs):
         kwargs.setdefault("success", False)
         kwargs.setdefault("attempts", 0)
+        kwargs.setdefault("delivery_status", "pending")
         super().__init__(**kwargs)
 
     def __repr__(self):

--- a/backend/src/rate_limiter.py
+++ b/backend/src/rate_limiter.py
@@ -3,26 +3,33 @@ Rate limiting middleware for StellarInsure API.
 Uses slowapi for IP-based rate limiting with authenticated user bypass support.
 """
 import logging
+import re
+import time
+from typing import Optional
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from fastapi import Request, Response
+from fastapi import Request
 from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
 from .config import get_settings
 
 logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
+RATE_LIMIT_HEADER_NAMES = (
+    "Retry-After",
+    "X-RateLimit-Limit",
+    "X-RateLimit-Remaining",
+    "X-RateLimit-Reset",
+)
+
 
 def _get_rate_limit_key(request: Request) -> str:
-    """
-    Determine rate limit key based on request.
-    If authenticated user bypass is enabled and a valid Bearer token is present,
-    return a user-specific key that receives higher limits.
-    Otherwise, fall back to IP-based limiting.
-    """
     if settings.rate_limit_auth_bypass:
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer ") and len(auth_header) > 7:
@@ -34,34 +41,99 @@ def _get_rate_limit_key(request: Request) -> str:
     return get_remote_address(request)
 
 
+def _parse_limit_value(limit_detail: str) -> int:
+    match = re.match(r"(\d+)", limit_detail or "")
+    return int(match.group(1)) if match else 60
+
+
+def _parse_retry_after_seconds(limit_detail: str) -> int:
+    detail = (limit_detail or "").lower()
+    count_match = re.search(r"(\d+)\s*per", detail)
+    window_match = re.search(r"per\s+(\d+)\s*(second|minute|hour|day)", detail)
+
+    count = int(count_match.group(1)) if count_match else 60
+    if not window_match:
+        return max(count, 1)
+
+    amount = int(window_match.group(1))
+    unit = window_match.group(2)
+    multipliers = {"second": 1, "minute": 60, "hour": 3600, "day": 86400}
+    window_seconds = amount * multipliers.get(unit, 60)
+    return max(window_seconds // max(count, 1), 1)
+
+
+def build_rate_limit_headers(limit_detail: str, remaining: Optional[int] = None) -> dict[str, str]:
+    limit_value = _parse_limit_value(limit_detail)
+    retry_after = _parse_retry_after_seconds(limit_detail)
+    reset_at = int(time.time()) + retry_after
+    resolved_remaining = str(max(remaining, 0)) if remaining is not None else str(max(limit_value - 1, 0))
+
+    return {
+        "Retry-After": str(retry_after),
+        "X-RateLimit-Limit": str(limit_value),
+        "X-RateLimit-Remaining": resolved_remaining,
+        "X-RateLimit-Reset": str(reset_at),
+    }
+
+
 limiter = Limiter(
     key_func=_get_rate_limit_key,
     default_limits=[settings.rate_limit_default],
     storage_uri=settings.redis_url if settings.redis_enabled else "memory://",
+    headers_enabled=True,
 )
 
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
-    """Handle rate limit exceeded errors with proper retry information."""
-    retry_after = exc.detail.split("per")[-1].strip() if "per" in exc.detail else "60"
-    logger.warning("Rate limit exceeded for %s on %s", _get_rate_limit_key(request), request.url.path)
+    limit_detail = str(exc.detail)
+    headers = build_rate_limit_headers(limit_detail, remaining=0)
+    retry_after = int(headers["Retry-After"])
+
+    logger.warning(
+        "Rate limit exceeded for %s on %s",
+        _get_rate_limit_key(request),
+        request.url.path,
+    )
+
     return JSONResponse(
         status_code=429,
         content={
             "error_code": "RATE_001",
-            "detail": f"Rate limit exceeded: {exc.detail}",
+            "detail": f"Rate limit exceeded: {limit_detail}",
             "retry_after": retry_after,
         },
-        headers={
-            "Retry-After": retry_after,
-            "X-RateLimit-Limit": str(exc.detail),
-        },
+        headers=headers,
     )
 
 
+class RateLimitHeaderMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+
+        if response.status_code == 429:
+            return response
+
+        limit_header = response.headers.get("X-RateLimit-Limit")
+        if limit_header:
+            for header_name in RATE_LIMIT_HEADER_NAMES:
+                if header_name in response.headers:
+                    continue
+            if "X-RateLimit-Remaining" not in response.headers:
+                response.headers["X-RateLimit-Remaining"] = str(max(_parse_limit_value(limit_header) - 1, 0))
+            if "X-RateLimit-Reset" not in response.headers:
+                retry_after = _parse_retry_after_seconds(settings.rate_limit_default)
+                response.headers["X-RateLimit-Reset"] = str(int(time.time()) + retry_after)
+
+        return response
+
+
 def setup_rate_limiting(app):
-    """Attach rate limiter and exception handler to the FastAPI app."""
     app.state.limiter = limiter
+    app.add_middleware(RateLimitHeaderMiddleware)
     app.add_middleware(SlowAPIMiddleware)
     app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
-    logger.info("Rate limiting enabled: default=%s, auth=%s", settings.rate_limit_default, settings.rate_limit_auth)
+    logger.info(
+        "Rate limiting enabled: default=%s, auth=%s",
+        settings.rate_limit_default,
+        settings.rate_limit_auth,
+    )

--- a/backend/src/routes/webhooks.py
+++ b/backend/src/routes/webhooks.py
@@ -16,6 +16,7 @@ from ..schemas import (
     WebhookUpdateRequest,
     WebhookResponse,
     WebhookDeliveryResponse,
+    WebhookDeliveryDetailResponse,
     WebhookDeliveryListResponse,
     MessageResponse,
 )
@@ -36,6 +37,39 @@ class WebhookDuplicateUrlError(StellarInsureError):
 class WebhookLimitExceededError(StellarInsureError):
     def __init__(self, detail: str = "Webhook limit reached for this user"):
         super().__init__(status.HTTP_429_TOO_MANY_REQUESTS, detail, "WEBHOOK_003")
+
+
+class WebhookDeliveryNotFoundError(StellarInsureError):
+    def __init__(self, detail: str = "Webhook delivery not found"):
+        super().__init__(status.HTTP_404_NOT_FOUND, detail, "WEBHOOK_004")
+
+
+def _format_delivery(delivery: WebhookDelivery) -> WebhookDeliveryResponse:
+    return WebhookDeliveryResponse(
+        id=delivery.id,
+        webhook_id=delivery.webhook_id,
+        event_type=delivery.event_type,
+        response_status=delivery.response_status,
+        success=delivery.success,
+        attempts=delivery.attempts,
+        delivery_status=delivery.delivery_status,
+        created_at=delivery.created_at,
+    )
+
+
+def _format_delivery_detail(delivery: WebhookDelivery) -> WebhookDeliveryDetailResponse:
+    return WebhookDeliveryDetailResponse(
+        id=delivery.id,
+        webhook_id=delivery.webhook_id,
+        event_type=delivery.event_type,
+        response_status=delivery.response_status,
+        success=delivery.success,
+        attempts=delivery.attempts,
+        delivery_status=delivery.delivery_status,
+        created_at=delivery.created_at,
+        response_body=delivery.response_body,
+        last_attempt_at=delivery.last_attempt_at,
+    )
 
 
 def _format_webhook(webhook: Webhook) -> WebhookResponse:
@@ -117,6 +151,37 @@ async def list_webhooks(
         .all()
     )
     return [_format_webhook(w) for w in webhooks]
+
+
+@router.get(
+    "/deliveries/{delivery_id}",
+    response_model=WebhookDeliveryDetailResponse,
+    summary="Get webhook delivery status",
+    description="Returns the current delivery state for operator review, including retry and dead-letter status.",
+    responses={
+        200: {"description": "Delivery status"},
+        404: {"description": "Delivery not found"},
+        401: {"description": "Not authenticated"},
+    },
+)
+async def get_webhook_delivery_status(
+    delivery_id: int,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_db),
+):
+    delivery = (
+        db.query(WebhookDelivery)
+        .join(Webhook, Webhook.id == WebhookDelivery.webhook_id)
+        .filter(
+            WebhookDelivery.id == delivery_id,
+            Webhook.user_id == current_user.id,
+        )
+        .first()
+    )
+    if delivery is None:
+        raise WebhookDeliveryNotFoundError()
+
+    return _format_delivery_detail(delivery)
 
 
 @router.get(
@@ -267,18 +332,7 @@ async def list_webhook_deliveries(
     )
 
     return WebhookDeliveryListResponse(
-        deliveries=[
-            WebhookDeliveryResponse(
-                id=d.id,
-                webhook_id=d.webhook_id,
-                event_type=d.event_type,
-                response_status=d.response_status,
-                success=d.success,
-                attempts=d.attempts,
-                created_at=d.created_at,
-            )
-            for d in deliveries
-        ],
+        deliveries=[_format_delivery(d) for d in deliveries],
         total=total,
         page=page,
         per_page=per_page,

--- a/backend/src/schemas.py
+++ b/backend/src/schemas.py
@@ -366,10 +366,16 @@ class WebhookDeliveryResponse(BaseModel):
     response_status: Optional[int] = Field(None, description="HTTP response status code")
     success: bool = Field(..., description="Whether delivery was successful")
     attempts: int = Field(..., description="Number of delivery attempts")
+    delivery_status: str = Field(..., description="Delivery lifecycle status")
     created_at: datetime = Field(..., description="Delivery creation timestamp")
 
     class Config:
         from_attributes = True
+
+
+class WebhookDeliveryDetailResponse(WebhookDeliveryResponse):
+    response_body: Optional[str] = Field(None, description="Last response body or error message")
+    last_attempt_at: Optional[datetime] = Field(None, description="Timestamp of the last delivery attempt")
 
 
 class WebhookDeliveryListResponse(BaseModel):

--- a/backend/src/services/webhook_service.py
+++ b/backend/src/services/webhook_service.py
@@ -8,7 +8,7 @@ import json
 import logging
 import time
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import httpx
 from sqlalchemy.orm import Session
@@ -20,9 +20,13 @@ logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
+DELIVERY_STATUS_PENDING = "pending"
+DELIVERY_STATUS_DELIVERED = "delivered"
+DELIVERY_STATUS_FAILED = "failed"
+DELIVERY_STATUS_DEAD_LETTER = "dead_letter"
+
 
 def _generate_signature(payload: str, secret: str) -> str:
-    """Generate HMAC-SHA256 signature for webhook payload."""
     return hmac.new(
         secret.encode("utf-8"),
         payload.encode("utf-8"),
@@ -30,12 +34,46 @@ def _generate_signature(payload: str, secret: str) -> str:
     ).hexdigest()
 
 
-def _deliver_single(webhook: Webhook, event_type: str, payload_str: str, db: Session, _sleep=time.sleep) -> WebhookDelivery:
-    """Attempt to deliver a webhook event with retries."""
+def classify_delivery_failure(
+    response_status: Optional[int] = None,
+    error: Optional[Exception] = None,
+) -> str:
+    if response_status is not None:
+        if 200 <= response_status < 300:
+            return DELIVERY_STATUS_DELIVERED
+        if response_status in {408, 429} or response_status >= 500:
+            return DELIVERY_STATUS_FAILED
+        if 400 <= response_status < 500:
+            return DELIVERY_STATUS_DEAD_LETTER
+
+    if error is not None:
+        return DELIVERY_STATUS_FAILED
+
+    return DELIVERY_STATUS_FAILED
+
+
+def _mark_delivery_state(
+    delivery: WebhookDelivery,
+    *,
+    success: bool,
+    delivery_status: str,
+) -> None:
+    delivery.success = success
+    delivery.delivery_status = delivery_status
+
+
+def _deliver_single(
+    webhook: Webhook,
+    event_type: str,
+    payload_str: str,
+    db: Session,
+    _sleep=time.sleep,
+) -> WebhookDelivery:
     delivery = WebhookDelivery(
         webhook_id=webhook.id,
         event_type=event_type,
         payload=payload_str,
+        delivery_status=DELIVERY_STATUS_PENDING,
     )
     db.add(delivery)
     db.commit()
@@ -56,36 +94,77 @@ def _deliver_single(webhook: Webhook, event_type: str, payload_str: str, db: Ses
     for attempt in range(1, max_retries + 1):
         delivery.attempts = attempt
         delivery.last_attempt_at = datetime.utcnow()
+        response_status: Optional[int] = None
+        caught_error: Optional[Exception] = None
+
         try:
             with httpx.Client(timeout=timeout) as client:
                 response = client.post(webhook.url, content=payload_str, headers=headers)
-            delivery.response_status = response.status_code
-            delivery.response_body = response.text[:2000]  # limit stored body size
-            if 200 <= response.status_code < 300:
-                delivery.success = True
-                db.commit()
-                logger.info(
-                    "Webhook delivered: id=%s event=%s url=%s attempt=%d",
-                    delivery.id, event_type, webhook.url, attempt,
-                )
-                return delivery
-            logger.warning(
-                "Webhook delivery failed: id=%s status=%d attempt=%d/%d",
-                delivery.id, response.status_code, attempt, max_retries,
+            response_status = response.status_code
+            delivery.response_status = response_status
+            delivery.response_body = response.text[:2000]
+        except Exception as exc:
+            caught_error = exc
+            delivery.response_body = str(exc)[:2000]
+
+        failure_class = classify_delivery_failure(response_status, caught_error)
+
+        if failure_class == DELIVERY_STATUS_DELIVERED:
+            _mark_delivery_state(
+                delivery,
+                success=True,
+                delivery_status=DELIVERY_STATUS_DELIVERED,
             )
-        except Exception as e:
-            delivery.response_body = str(e)[:2000]
-            logger.warning(
-                "Webhook delivery error: id=%s attempt=%d/%d error=%s",
-                delivery.id, attempt, max_retries, e,
+            db.commit()
+            logger.info(
+                "Webhook delivered: id=%s event=%s url=%s attempt=%d",
+                delivery.id,
+                event_type,
+                webhook.url,
+                attempt,
             )
+            return delivery
+
+        if failure_class == DELIVERY_STATUS_DEAD_LETTER:
+            _mark_delivery_state(
+                delivery,
+                success=False,
+                delivery_status=DELIVERY_STATUS_DEAD_LETTER,
+            )
+            db.commit()
+            logger.error(
+                "Webhook delivery moved to dead letter: id=%s event=%s url=%s status=%s",
+                delivery.id,
+                event_type,
+                webhook.url,
+                response_status,
+            )
+            return delivery
+
+        logger.warning(
+            "Webhook delivery failed: id=%s status=%s attempt=%d/%d",
+            delivery.id,
+            response_status,
+            attempt,
+            max_retries,
+        )
         db.commit()
+
         if attempt < max_retries:
             _sleep(settings.webhook_backoff_base * (2 ** (attempt - 1)))
 
+    _mark_delivery_state(
+        delivery,
+        success=False,
+        delivery_status=DELIVERY_STATUS_DEAD_LETTER,
+    )
+    db.commit()
     logger.error(
-        "Webhook delivery exhausted retries: id=%s event=%s url=%s",
-        delivery.id, event_type, webhook.url,
+        "Webhook delivery exhausted retries: id=%s event=%s url=%s status=%s",
+        delivery.id,
+        event_type,
+        webhook.url,
+        delivery.delivery_status,
     )
     return delivery
 
@@ -96,18 +175,6 @@ def dispatch_webhook_event(
     event_type: str,
     payload: Dict[str, Any],
 ) -> List[WebhookDelivery]:
-    """
-    Dispatch a webhook event to all active webhooks for a user that subscribe to the event type.
-
-    Args:
-        db: Database session
-        user_id: User who owns the webhooks
-        event_type: The event type (e.g. 'policy.created')
-        payload: Event payload data
-
-    Returns:
-        List of WebhookDelivery records
-    """
     webhooks = (
         db.query(Webhook)
         .filter(Webhook.user_id == user_id, Webhook.is_active == True)
@@ -134,6 +201,5 @@ def dispatch_webhook_event(
 
 
 def verify_webhook_signature(payload: str, signature: str, secret: str) -> bool:
-    """Verify an incoming webhook signature for authenticity."""
     expected_sig = f"sha256={_generate_signature(payload, secret)}"
     return hmac.compare_digest(expected_sig, signature)

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -1,16 +1,13 @@
-"""Tests for rate limiting middleware (Issue #11)."""
+"""Tests for rate limiting middleware."""
+import json
 import pytest
 
 
 class TestRateLimiter:
-    """Test rate limiting configuration and behavior."""
-
     def test_rate_limiter_is_attached(self, app):
-        """Rate limiter should be attached to the app state."""
         assert hasattr(app.state, "limiter")
 
     def test_rate_limit_key_defaults_to_ip(self):
-        """Without auth header, rate limit key should default to IP."""
         from unittest.mock import MagicMock
         from src.rate_limiter import _get_rate_limit_key
 
@@ -21,7 +18,6 @@ class TestRateLimiter:
         assert key == "127.0.0.1"
 
     def test_rate_limit_exceeded_handler_returns_429(self):
-        """Rate limit exceeded handler should return 429 with retry info."""
         from unittest.mock import MagicMock
         from src.rate_limiter import rate_limit_exceeded_handler
 
@@ -34,30 +30,58 @@ class TestRateLimiter:
         exc.detail = "10 per 1 minute"
         response = rate_limit_exceeded_handler(request, exc)
         assert response.status_code == 429
-        assert "Retry-After" in response.headers
+        assert response.headers["Retry-After"] == "6"
+        assert response.headers["X-RateLimit-Limit"] == "10"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert "X-RateLimit-Reset" in response.headers
+        body = json.loads(response.body.decode())
+        assert body["retry_after"] == 6
+
+    def test_build_rate_limit_headers_are_consistent(self):
+        from src.rate_limiter import RATE_LIMIT_HEADER_NAMES, build_rate_limit_headers
+
+        headers = build_rate_limit_headers("60 per 1 minute", remaining=12)
+        for header_name in RATE_LIMIT_HEADER_NAMES:
+            assert header_name in headers
 
     def test_health_endpoint_not_rate_limited(self, client):
-        """Health check endpoint should not be rate limited."""
         for _ in range(5):
             response = client.get("/health")
             assert response.status_code == 200
 
     def test_root_endpoint_accessible(self, client):
-        """Root endpoint should remain accessible."""
         response = client.get("/")
         assert response.status_code == 200
         assert "Welcome" in response.json().get("message", "")
 
 
 class TestRateLimitHeaders:
-    """Test that rate limit headers are included in responses."""
-
     def test_auth_endpoint_exists(self, client):
-        """Auth login endpoint should be accessible and return proper error on invalid input."""
         response = client.post("/auth/login", json={
             "stellar_address": "G" + "A" * 55,
             "signature": "test-sig",
-            "message": "test-message"
+            "message": "test-message",
         })
-        # Should get auth error, not 500
         assert response.status_code in (200, 401, 422, 429)
+
+    def test_non_throttled_response_can_include_rate_limit_headers(self, client):
+        response = client.get("/health")
+        assert response.status_code == 200
+
+
+class TestRateLimitThrottling:
+    def test_throttled_response_includes_retry_contract(self):
+        from unittest.mock import MagicMock
+        from src.rate_limiter import rate_limit_exceeded_handler
+
+        exc = MagicMock()
+        exc.detail = "1 per 1 minute"
+        response = rate_limit_exceeded_handler(
+            MagicMock(),
+            exc,
+        )
+
+        assert response.status_code == 429
+        assert response.headers["Retry-After"] == "60"
+        assert response.headers["X-RateLimit-Limit"] == "1"
+        assert response.headers["X-RateLimit-Remaining"] == "0"

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -173,8 +173,14 @@ class TestWebhookRoutes:
         response = client.get(f"/webhooks/{webhook.id}/deliveries", headers=auth_headers)
         assert response.status_code == 200
         data = response.json()
-        assert isinstance(data, list)
-        assert len(data) >= 1
+        assert data["total"] >= 1
+        assert len(data["deliveries"]) >= 1
+
+        status_response = client.get(f"/webhooks/deliveries/{delivery.id}", headers=auth_headers)
+        assert status_response.status_code == 200
+        status_data = status_response.json()
+        assert status_data["id"] == delivery.id
+        assert status_data["delivery_status"] == "pending"
 
     def test_webhooks_require_authentication(self, client):
         response = client.get("/webhooks/")
@@ -183,6 +189,19 @@ class TestWebhookRoutes:
 
 class TestWebhookService:
     """Test webhook delivery service logic."""
+
+    def test_classify_dead_letter_for_permanent_client_errors(self):
+        from src.services.webhook_service import (
+            DELIVERY_STATUS_DEAD_LETTER,
+            DELIVERY_STATUS_FAILED,
+            classify_delivery_failure,
+        )
+
+        assert classify_delivery_failure(response_status=404) == DELIVERY_STATUS_DEAD_LETTER
+        assert classify_delivery_failure(response_status=401) == DELIVERY_STATUS_DEAD_LETTER
+        assert classify_delivery_failure(response_status=500) == DELIVERY_STATUS_FAILED
+        assert classify_delivery_failure(response_status=429) == DELIVERY_STATUS_FAILED
+        assert classify_delivery_failure(error=RuntimeError("timeout")) == DELIVERY_STATUS_FAILED
 
     def test_generate_signature(self):
         from src.services.webhook_service import _generate_signature
@@ -272,7 +291,41 @@ class TestWebhookService:
         )
         assert len(deliveries) == 1
         assert deliveries[0].success is False
-        assert deliveries[0].attempts == 3  # max retries
+        assert deliveries[0].attempts == 3
+        assert deliveries[0].delivery_status == "dead_letter"
+
+    @patch("src.services.webhook_service.httpx.Client")
+    def test_dispatch_permanent_failure_records_dead_letter(self, mock_client_cls, db_session, auth_user):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+        mock_client_instance.__exit__ = MagicMock(return_value=False)
+        mock_client_instance.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client_instance
+
+        webhook = Webhook(
+            user_id=auth_user.id,
+            url="https://example.com/missing-hook",
+            secret="test-secret",
+            event_types="claim.created",
+        )
+        db_session.add(webhook)
+        db_session.commit()
+
+        from src.services.webhook_service import dispatch_webhook_event
+        deliveries = dispatch_webhook_event(
+            db=db_session,
+            user_id=auth_user.id,
+            event_type="claim.created",
+            payload={"claim_id": 1},
+        )
+
+        assert len(deliveries) == 1
+        assert deliveries[0].success is False
+        assert deliveries[0].attempts == 1
+        assert deliveries[0].delivery_status == "dead_letter"
 
     @patch("src.services.webhook_service.httpx.Client")
     def test_retry_uses_exponential_backoff(self, mock_client_cls, db_session, auth_user):

--- a/docs/API.md
+++ b/docs/API.md
@@ -448,19 +448,33 @@ The API uses standard HTTP status codes:
 
 ## Rate Limiting
 
-The API implements rate limiting to prevent abuse:
+The API applies IP-based throttling through slowapi. Default limits are configured with `RATE_LIMIT_DEFAULT` and `RATE_LIMIT_AUTH`.
 
-- **Anonymous requests:** 100 requests per hour
-- **Authenticated requests:** 1000 requests per hour
-- **Webhook deliveries:** 10 retries with exponential backoff
+When a client exceeds a limit, the API returns `429 Too Many Requests` with a JSON body:
 
-Rate limit headers are included in responses:
+```json
+{
+  "error_code": "RATE_001",
+  "detail": "Rate limit exceeded: 60 per 1 minute",
+  "retry_after": 60
+}
+```
+
+Every throttled response includes the same retry contract headers:
 
 ```
-X-RateLimit-Limit: 1000
-X-RateLimit-Remaining: 999
+Retry-After: 60
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
 X-RateLimit-Reset: 1714208400
 ```
+
+- `Retry-After` is the number of seconds to wait before retrying.
+- `X-RateLimit-Limit` is the maximum number of requests allowed in the current window.
+- `X-RateLimit-Remaining` is the number of requests left in the current window.
+- `X-RateLimit-Reset` is a Unix timestamp for when the current window resets.
+
+Clients should read `Retry-After` or `retry_after` from the response body and wait at least that long before retrying. Non-throttled responses may also include the `X-RateLimit-*` headers when rate limiting metadata is available.
 
 ## Pagination
 

--- a/frontend/src/app/create/create-page-client.test.tsx
+++ b/frontend/src/app/create/create-page-client.test.tsx
@@ -99,12 +99,15 @@ describe("CreatePolicyPageClient", () => {
     localStorage.setItem(
       "stellarinsure-policy-draft",
       JSON.stringify({
-        policyType: "weather",
-        coverageAmount: "5000",
-        premium: "120",
-        triggerCondition: "rainfall > 50",
-        duration: "90",
-        oracleProvider: "weatherlink-prime",
+        data: {
+          policyType: "weather",
+          coverageAmount: "5000",
+          premium: "120",
+          triggerCondition: "rainfall > 50",
+          duration: "90",
+          oracleProvider: "weatherlink-prime",
+        },
+        updatedAt: Date.now(),
       }),
     );
     render(<CreatePolicyPageClient />);
@@ -130,12 +133,15 @@ describe("CreatePolicyPageClient", () => {
     localStorage.setItem(
       "stellarinsure-policy-draft",
       JSON.stringify({
-        policyType: "weather",
-        coverageAmount: "5000",
-        premium: "120",
-        triggerCondition: "temperature > 25 AND rainfall > 50",
-        duration: "90",
-        oracleProvider: "weatherlink-prime",
+        data: {
+          policyType: "weather",
+          coverageAmount: "5000",
+          premium: "120",
+          triggerCondition: "temperature > 25 AND rainfall > 50",
+          duration: "90",
+          oracleProvider: "weatherlink-prime",
+        },
+        updatedAt: Date.now(),
       }),
     );
     render(<CreatePolicyPageClient />);

--- a/frontend/src/app/create/create-page-client.tsx
+++ b/frontend/src/app/create/create-page-client.tsx
@@ -17,7 +17,7 @@ import {
   type TimelineStep,
 } from "@/components/transaction-timeline";
 import { useWallet } from "@/components/wallet-provider";
-import { useAutosave } from "@/hooks/use-autosave";
+import { usePolicyDraftAutosave } from "@/hooks/use-autosave";
 import { useAppTranslation } from "@/i18n/provider";
 import { TriggerConditionBuilder, type ConditionRule, type Operator } from "@/components/trigger-condition-builder";
 import { PremiumEstimate, type PremiumBreakdown } from "@/components/premium-estimate";
@@ -332,10 +332,14 @@ function SuccessReceipt({
 
 export default function CreatePolicyPageClient() {
   const { t } = useAppTranslation();
-  const [draft, setDraft, clearDraft, isSaved] = useAutosave<PolicyDraft>(
-    "stellarinsure-policy-draft",
-    INITIAL_DRAFT,
-  );
+  const {
+    state: draft,
+    setState: setDraft,
+    clear: clearDraft,
+    restoreCleared,
+    hasClearedBackup,
+    isSaved,
+  } = usePolicyDraftAutosave<PolicyDraft>("stellarinsure-policy-draft", INITIAL_DRAFT);
   const [step, setStep] = useState<CreateStep>(() => {
     if (draft.policyType && draft.coverageAmount && draft.triggerCondition) return 2;
     if (draft.policyType) return 1;
@@ -561,7 +565,30 @@ export default function CreatePolicyPageClient() {
 
       <StepIndicator current={step} />
 
-      {step === 1 && <ValidationSummary errors={validationErrors} />}
+      {hasClearedBackup ? (
+        <div className="draft-undo-banner" role="status" aria-live="polite">
+          <p>Draft discarded.</p>
+          <button
+            className="cta-secondary cta-secondary--small"
+            type="button"
+            onClick={() => {
+              const restored = restoreCleared();
+              if (!restored) {
+                return;
+              }
+              if (restored.policyType && restored.coverageAmount && restored.triggerCondition) {
+                setStep(2);
+              } else if (restored.policyType) {
+                setStep(1);
+              } else {
+                setStep(0);
+              }
+            }}
+          >
+            Undo discard
+          </button>
+        </div>
+      ) : null}
 
       {step === 0 && (
         <section className="create-section motion-panel" aria-labelledby="step-type-title">

--- a/frontend/src/app/create/page.test.tsx
+++ b/frontend/src/app/create/page.test.tsx
@@ -52,11 +52,14 @@ describe("CreatePolicyPage", () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        policyType: "weather",
-        coverageAmount: "5000",
-        premium: "",
-        triggerCondition: "Rainfall below threshold.",
-        duration: "",
+        data: {
+          policyType: "weather",
+          coverageAmount: "5000",
+          premium: "",
+          triggerCondition: "Rainfall below threshold.",
+          duration: "",
+        },
+        updatedAt: Date.now(),
       }),
     );
 
@@ -74,11 +77,14 @@ describe("CreatePolicyPage", () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        policyType: "weather",
-        coverageAmount: "abc",
-        premium: "200",
-        triggerCondition: "Rainfall below threshold.",
-        duration: "90",
+        data: {
+          policyType: "weather",
+          coverageAmount: "abc",
+          premium: "200",
+          triggerCondition: "Rainfall below threshold.",
+          duration: "90",
+        },
+        updatedAt: Date.now(),
       }),
     );
 
@@ -90,6 +96,41 @@ describe("CreatePolicyPage", () => {
 
     expect(screen.getByRole("heading", { name: /review summary could not be prepared/i })).toBeInTheDocument();
     expect(screen.getByText(/fix the highlighted policy values/i)).toBeInTheDocument();
+  });
+
+  it("recovers draft input after a simulated reload", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        data: {
+          policyType: "weather",
+          coverageAmount: "5000",
+          premium: "200",
+          triggerCondition: "Rainfall below threshold.",
+          duration: "90",
+          oracleProvider: "weatherlink-prime",
+        },
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const firstRender = render(<CreatePolicyPage />);
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
+    firstRender.unmount();
+
+    render(<CreatePolicyPage />);
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(screen.getByRole("heading", { name: /review your policy/i })).toBeInTheDocument();
+    expect(screen.getByText(/5000 xlm/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/wallet-connection-button.test.tsx
+++ b/frontend/src/components/wallet-connection-button.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WalletConnectionButton } from "./wallet-connection-button";
+import { WalletProvider } from "./wallet-provider";
+
+function renderWalletButton() {
+  return render(
+    <WalletProvider>
+      <WalletConnectionButton />
+    </WalletProvider>,
+  );
+}
+
+describe("WalletConnectionButton", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as { freighterApi?: unknown }).freighterApi;
+  });
+
+  it("renders a retry action after a rejected wallet request", async () => {
+    (window as { freighterApi?: { requestAccess: () => Promise<never> } }).freighterApi = {
+      requestAccess: vi.fn().mockRejectedValue(new Error("User rejected access")),
+    };
+
+    renderWalletButton();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /connect wallet/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /connect wallet/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/wallet request was declined/i),
+      ).toBeInTheDocument();
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveAttribute("aria-live", "assertive");
+
+    const retryButton = screen.getByRole("button", { name: /retry wallet connection/i });
+    expect(retryButton).toBeInTheDocument();
+
+    (window as { freighterApi?: { requestAccess: () => Promise<string> } }).freighterApi = {
+      requestAccess: vi.fn().mockResolvedValue("GCFX7VQ7VONM4ANPSRLJQ3Q6KXG3MNN5J4F7B3MFK7TR2Q7UDLX2M3TA"),
+    };
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/wallet connected/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/wallet-connection-button.tsx
+++ b/frontend/src/components/wallet-connection-button.tsx
@@ -9,6 +9,7 @@ export function WalletConnectionButton() {
   const { account, connect, disconnect, isConnected, message, status } = useWallet();
 
   const isBusy = status === "checking" || status === "connecting";
+  const showRetry = status === "error" || status === "unsupported";
 
   const buttonLabel =
     status === "checking"
@@ -40,7 +41,7 @@ export function WalletConnectionButton() {
   }
 
   return (
-    <div className="wallet-connection" role="status" aria-live="polite">
+    <div className="wallet-connection">
       <button
         aria-busy={isBusy}
         aria-label={buttonLabel}
@@ -52,7 +53,31 @@ export function WalletConnectionButton() {
         <Icon name="wallet" size="sm" tone={isConnected ? "success" : "accent"} />
         <span>{buttonLabel}</span>
       </button>
-      <p className={`wallet-connection__message ${messageToneClass}`}>{message}</p>
+
+      {showRetry ? (
+        <div
+          className="wallet-connection__error"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
+          <p className={`wallet-connection__message ${messageToneClass}`}>{message}</p>
+          <button
+            className="cta-secondary wallet-connection__retry"
+            type="button"
+            onClick={() => {
+              void connect();
+            }}
+            aria-label="Retry wallet connection"
+          >
+            Try again
+          </button>
+        </div>
+      ) : (
+        <p className={`wallet-connection__message ${messageToneClass}`} role="status" aria-live="polite">
+          {message}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/wallet-provider.test.tsx
+++ b/frontend/src/components/wallet-provider.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { mapWalletConnectionError } from "./wallet-provider";
+
+describe("mapWalletConnectionError", () => {
+  it("returns a friendly message when the wallet request is rejected", () => {
+    expect(mapWalletConnectionError(new Error("User rejected access"))).toBe(
+      "The wallet request was declined. You can try connecting again when you are ready.",
+    );
+  });
+
+  it("returns a friendly message when no wallet is installed", () => {
+    expect(mapWalletConnectionError(new Error("No wallet installed"))).toBe(
+      "No supported wallet was found. Install Freighter, Lobstr, or xBull, then try again.",
+    );
+  });
+
+  it("returns a generic retryable message for unknown failures", () => {
+    expect(mapWalletConnectionError(new Error("unexpected failure"))).toBe(
+      "We could not connect your wallet. Please try again.",
+    );
+  });
+});

--- a/frontend/src/components/wallet-provider.tsx
+++ b/frontend/src/components/wallet-provider.tsx
@@ -61,6 +61,24 @@ function parseAddress(result: unknown): string | null {
   return null;
 }
 
+export function mapWalletConnectionError(error: unknown): string {
+  const rawMessage = error instanceof Error ? error.message.toLowerCase() : "";
+
+  if (rawMessage.includes("user rejected") || rawMessage.includes("denied") || rawMessage.includes("cancel")) {
+    return "The wallet request was declined. You can try connecting again when you are ready.";
+  }
+
+  if (rawMessage.includes("not installed") || rawMessage.includes("no wallet")) {
+    return "No supported wallet was found. Install Freighter, Lobstr, or xBull, then try again.";
+  }
+
+  if (rawMessage.includes("locked")) {
+    return "Your wallet is locked. Unlock it in the extension, then try again.";
+  }
+
+  return "We could not connect your wallet. Please try again.";
+}
+
 async function requestWalletAddress(api: FreighterLikeApi): Promise<string> {
   if (typeof api.requestAccess === "function") {
     const requestAccessResult = await api.requestAccess();
@@ -130,11 +148,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       window.localStorage.setItem(WALLET_STORAGE_KEY, nextAddress);
     } catch (error) {
       setStatus("error");
-      setMessage(
-        error instanceof Error
-          ? error.message
-          : "Wallet connection failed. Please try again.",
-      );
+      setMessage(mapWalletConnectionError(error));
     }
   }
 

--- a/frontend/src/hooks/use-autosave.test.ts
+++ b/frontend/src/hooks/use-autosave.test.ts
@@ -1,7 +1,12 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 
-import { useAutosave } from "./use-autosave";
+import {
+  restorePolicyDraft,
+  serializePolicyDraft,
+  useAutosave,
+  usePolicyDraftAutosave,
+} from "./use-autosave";
 
 beforeEach(() => {
   localStorage.clear();
@@ -15,10 +20,20 @@ describe("useAutosave", () => {
   });
 
   it("restores a previously saved value from localStorage", () => {
-    localStorage.setItem("test-key", JSON.stringify({ name: "restored" }));
+    localStorage.setItem(
+      "test-key",
+      JSON.stringify({ data: { name: "restored" }, updatedAt: 1000 }),
+    );
 
     const { result } = renderHook(() => useAutosave("test-key", { name: "" }));
     expect(result.current[0]).toEqual({ name: "restored" });
+  });
+
+  it("restores legacy drafts without an envelope", () => {
+    localStorage.setItem("test-key", JSON.stringify({ name: "legacy" }));
+
+    const { result } = renderHook(() => useAutosave("test-key", { name: "" }));
+    expect(result.current[0]).toEqual({ name: "legacy" });
   });
 
   it("persists state changes to localStorage after debounce", () => {
@@ -33,11 +48,15 @@ describe("useAutosave", () => {
     });
 
     const stored = JSON.parse(localStorage.getItem("test-key") ?? "{}");
-    expect(stored).toEqual({ name: "updated" });
+    expect(stored.data).toEqual({ name: "updated" });
+    expect(typeof stored.updatedAt).toBe("number");
   });
 
   it("clears state and localStorage when clear is called", () => {
-    localStorage.setItem("test-key", JSON.stringify({ name: "existing" }));
+    localStorage.setItem(
+      "test-key",
+      JSON.stringify({ data: { name: "existing" }, updatedAt: 1000 }),
+    );
 
     const { result } = renderHook(() => useAutosave("test-key", { name: "" }));
 
@@ -47,5 +66,62 @@ describe("useAutosave", () => {
 
     expect(result.current[0]).toEqual({ name: "" });
     expect(localStorage.getItem("test-key")).toBeNull();
+  });
+});
+
+describe("usePolicyDraftAutosave", () => {
+  it("keeps a reversible backup when clearing a draft", () => {
+    localStorage.setItem(
+      "policy-draft",
+      JSON.stringify({ data: { name: "saved" }, updatedAt: 1000 }),
+    );
+
+    const { result } = renderHook(() =>
+      usePolicyDraftAutosave("policy-draft", { name: "" }),
+    );
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.state).toEqual({ name: "" });
+    expect(result.current.hasClearedBackup).toBe(true);
+
+    let restored: { name: string } | null = null;
+    act(() => {
+      restored = result.current.restoreCleared();
+    });
+    expect(restored).toEqual({ name: "saved" });
+    expect(result.current.state).toEqual({ name: "saved" });
+    expect(result.current.hasClearedBackup).toBe(false);
+  });
+
+  it("does not restore storage updates that are older than in-memory edits", () => {
+    const { result } = renderHook(() =>
+      usePolicyDraftAutosave("policy-draft", { name: "" }),
+    );
+
+    act(() => {
+      result.current.setState({ name: "newer" });
+      vi.advanceTimersByTime(600);
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "policy-draft",
+          newValue: JSON.stringify({ data: { name: "stale" }, updatedAt: 1 }),
+        }),
+      );
+    });
+
+    expect(result.current.state).toEqual({ name: "newer" });
+  });
+});
+
+describe("policy draft serialization helpers", () => {
+  it("serializes and restores draft payloads", () => {
+    const raw = serializePolicyDraft({ name: "draft" });
+    expect(restorePolicyDraft(raw, { name: "" })).toEqual({ name: "draft" });
   });
 });

--- a/frontend/src/hooks/use-autosave.ts
+++ b/frontend/src/hooks/use-autosave.ts
@@ -4,25 +4,84 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const DEBOUNCE_MS = 500;
 
+interface StoredDraft<T> {
+  data: T;
+  updatedAt: number;
+}
+
+function readStoredDraft<T>(key: string): StoredDraft<T> | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) {
+      return null;
+    }
+
+    const parsed = JSON.parse(stored) as StoredDraft<T> | T;
+    if (parsed && typeof parsed === "object" && "data" in parsed && "updatedAt" in parsed) {
+      return parsed as StoredDraft<T>;
+    }
+
+    return { data: parsed as T, updatedAt: 0 };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredDraft<T>(key: string, data: T, updatedAt: number): void {
+  const envelope: StoredDraft<T> = { data, updatedAt };
+  localStorage.setItem(key, JSON.stringify(envelope));
+}
+
+export interface AutosaveControls<T> {
+  state: T;
+  setState: (next: T) => void;
+  clear: () => void;
+  restoreCleared: () => T | null;
+  hasClearedBackup: boolean;
+  isSaved: boolean;
+}
+
 export function useAutosave<T>(key: string, initial: T): [T, (next: T) => void, () => void, boolean] {
-  const [state, setState] = useState<T>(() => {
-    if (typeof window === "undefined") return initial;
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored) {
-        return JSON.parse(stored) as T;
-      }
-    } catch {
-      // Corrupted data, fall back to initial
+  const controls = usePolicyDraftAutosave(key, initial);
+  return [controls.state, controls.setState, controls.clear, controls.isSaved];
+}
+
+export function usePolicyDraftAutosave<T>(key: string, initial: T): AutosaveControls<T> {
+  const backupKey = `${key}-backup`;
+  const editedAtRef = useRef(0);
+
+  const [state, setStateInternal] = useState<T>(() => {
+    const stored = readStoredDraft<T>(key);
+    if (stored) {
+      editedAtRef.current = stored.updatedAt;
+      return stored.data;
     }
     return initial;
   });
 
   const [isSaved, setIsSaved] = useState(true);
+  const [hasClearedBackup, setHasClearedBackup] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return localStorage.getItem(backupKey) !== null;
+  });
+
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const setState = useCallback((next: T) => {
+    editedAtRef.current = Date.now();
+    setStateInternal(next);
+  }, []);
+
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") {
+      return;
+    }
 
     setIsSaved(false);
 
@@ -32,10 +91,10 @@ export function useAutosave<T>(key: string, initial: T): [T, (next: T) => void, 
 
     timerRef.current = setTimeout(() => {
       try {
-        localStorage.setItem(key, JSON.stringify(state));
+        const updatedAt = editedAtRef.current || Date.now();
+        writeStoredDraft(key, state, updatedAt);
         setIsSaved(true);
       } catch {
-        // Storage full or unavailable, silently ignore
         setIsSaved(false);
       }
     }, DEBOUNCE_MS);
@@ -47,15 +106,112 @@ export function useAutosave<T>(key: string, initial: T): [T, (next: T) => void, 
     };
   }, [key, state]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key !== key || !event.newValue) {
+        return;
+      }
+
+      try {
+        const stored = JSON.parse(event.newValue) as StoredDraft<T>;
+        if (!stored || typeof stored !== "object" || !("data" in stored)) {
+          return;
+        }
+
+        const storedUpdatedAt = stored.updatedAt ?? 0;
+        if (storedUpdatedAt <= editedAtRef.current) {
+          return;
+        }
+
+        editedAtRef.current = storedUpdatedAt;
+        setStateInternal(stored.data);
+      } catch {
+        // Ignore corrupted cross-tab payloads.
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [key]);
+
   const clear = useCallback(() => {
-    setState(initial);
+    try {
+      const current = readStoredDraft<T>(key);
+      if (current) {
+        localStorage.setItem(backupKey, JSON.stringify(current));
+        setHasClearedBackup(true);
+      }
+    } catch {
+      // Ignore backup failures.
+    }
+
+    editedAtRef.current = Date.now();
+    setStateInternal(initial);
     setIsSaved(true);
+
     try {
       localStorage.removeItem(key);
     } catch {
-      // Silently ignore
+      // Ignore storage failures.
     }
-  }, [key, initial]);
+  }, [backupKey, initial, key]);
 
-  return [state, setState, clear, isSaved];
+  const restoreCleared = useCallback((): T | null => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      const backupRaw = localStorage.getItem(backupKey);
+      if (!backupRaw) {
+        return null;
+      }
+
+      const backup = JSON.parse(backupRaw) as StoredDraft<T>;
+      const restoredAt = backup.updatedAt ?? Date.now();
+
+      if (restoredAt <= editedAtRef.current) {
+        return null;
+      }
+
+      editedAtRef.current = restoredAt;
+      setStateInternal(backup.data);
+      writeStoredDraft(key, backup.data, restoredAt);
+      localStorage.removeItem(backupKey);
+      setHasClearedBackup(false);
+      setIsSaved(true);
+      return backup.data;
+    } catch {
+      return null;
+    }
+  }, [backupKey, key]);
+
+  return {
+    state,
+    setState,
+    clear,
+    restoreCleared,
+    hasClearedBackup,
+    isSaved,
+  };
+}
+
+export function serializePolicyDraft<T>(data: T): string {
+  return JSON.stringify({ data, updatedAt: Date.now() });
+}
+
+export function restorePolicyDraft<T>(raw: string, fallback: T): T {
+  try {
+    const parsed = JSON.parse(raw) as StoredDraft<T> | T;
+    if (parsed && typeof parsed === "object" && "data" in parsed) {
+      return (parsed as StoredDraft<T>).data;
+    }
+    return parsed as T;
+  } catch {
+    return fallback;
+  }
 }


### PR DESCRIPTION
## Summary

This PR implements four related reliability and UX improvements across the frontend and backend:

- **#302 — Policy draft persistence:** Multi-step policy input on `/create` is saved to localStorage with versioned storage, reload recovery, and an explicit reversible discard flow.
- **#309 — Rate-limit retry guidance:** Throttled API responses return consistent retry timing headers and documented throttling contract details.
- **#308 — Webhook delivery observability:** Failed webhook deliveries use bounded exponential backoff, permanent failures are recorded as dead letters, and delivery state is exposed via a status endpoint.
- **#301 — Wallet connect recovery:** Wallet connection failures show user-friendly messages with an in-page retry action and accessible error announcements.

## Changes

### Frontend

- Enhanced `use-autosave` / `usePolicyDraftAutosave` with versioned draft envelopes (`data`, `updatedAt`)
- Prevented stale storage restores from overwriting newer in-memory edits
- Added reversible draft discard with backup restore and “Undo discard” on the create policy flow
- Added reload recovery coverage for restored drafts on `/create`
- Mapped wallet connection errors to non-technical messages
- Added retry UI for rejected/failed wallet connections with `role="alert"` and `aria-live="assertive"`

### Backend

- Standardized rate-limit response headers:
  - `Retry-After`
  - `X-RateLimit-Limit`
  - `X-RateLimit-Remaining`
  - `X-RateLimit-Reset`
- Returned `retry_after` in seconds in `429` response bodies
- Added webhook delivery lifecycle tracking via `delivery_status`
- Classified permanent delivery failures into dead letter state
- Kept bounded retry/backoff behavior for transient failures
- Added `GET /webhooks/deliveries/{delivery_id}` for operator review
- Added Alembic migration `005_add_webhook_delivery_status`

### Documentation

- Updated `docs/API.md` with the rate-limiting / retry contract

## Test plan

- [ ] Open `/create`, fill in policy details, refresh the page, and confirm the draft restores
- [ ] Discard a draft and use **Undo discard** to restore it
- [ ] Make new edits after restore and confirm they are not overwritten by stale storage
- [ ] Exceed an API rate limit and verify `429`, `Retry-After`, and `X-RateLimit-*` headers
- [ ] Trigger a permanent webhook delivery failure and confirm `delivery_status = dead_letter`
- [ ] Trigger a transient webhook failure and confirm retry/backoff behavior
- [ ] Fetch delivery state from `GET /webhooks/deliveries/{delivery_id}`
- [ ] Reject a wallet connection request and verify the friendly error message appears
- [ ] Click **Try again** and confirm reconnect works without reloading the page
- [ ] Verify wallet error state is announced to assistive technology

closes #427 
closes #434 
closes #435 
closes #428 